### PR TITLE
Update container configuration for persistent data and port 5000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ GEMINI_MODEL=models/gemini-1.5-pro-latest
 MAX_UPLOAD_SIZE_MB=15
 # Gemini API 呼び出しのタイムアウト秒数
 OCR_REQUEST_TIMEOUT=300
+# 永続化ディレクトリを変更したい場合は以下を上書きします
+# DATA_ROOT=/data
+# UPLOAD_DIR=/data/uploads
+# JOB_HISTORY_DIR=/data/jobs
+# RESPONSE_HISTORY_DIR=/data/responses
+# API_KEY_DIR=/data/keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,24 @@
+# syntax=docker/dockerfile:1.5
 FROM python:3.11-slim
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PORT=8080
+    PORT=5000
 
 COPY backend/requirements.txt ./backend/requirements.txt
-RUN pip install --no-cache-dir -r backend/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r backend/requirements.txt
 
 COPY backend ./backend
 COPY frontend ./frontend
 
+RUN mkdir -p /data/uploads /data/jobs /data/responses /data/keys
+VOLUME ["/data/uploads", "/data/jobs", "/data/responses", "/data/keys"]
+
 WORKDIR /app/backend
 
-EXPOSE 8080
+EXPOSE 5000
 
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Gemini APIを利用して、PDFから以下の項目を抽出します。
 * Docker がインストールされていること。
 * プロジェクトのルートディレクトリに.envファイルを作成し、Gemini APIキーを記述していること。
   * `cp .env.example .env` でひな形をコピーし、値を編集してください。
+* ユーザーアップロード、ジョブ履歴、応答履歴、APIキーを保存するホスト側ディレクトリを用意し、コンテナの`/data`配下にバインドすること。
+  * 必要に応じて `.env` ファイルで `UPLOAD_DIR` などのパスを上書きできます。
 
 **.env ファイルの例:**
 
@@ -63,14 +65,21 @@ GEMINI\_API\_KEY="YOUR\_GEMINI\_API\_KEY"
 \# ビルド
 docker build -t westa-ocr .
 
+\# 永続化ディレクトリの作成
+mkdir -p data/uploads data/jobs data/responses data/keys
+
 \# コンテナ起動
 docker run \
   --env-file .env \
-  -p 8080:8080 \
+  -v $(pwd)/data/uploads:/data/uploads \
+  -v $(pwd)/data/jobs:/data/jobs \
+  -v $(pwd)/data/responses:/data/responses \
+  -v $(pwd)/data/keys:/data/keys \
+  -p 5000:5000 \
   --name westa-ocr \
   westa-ocr
 
-起動後、Webブラウザで http://localhost:8080 にアクセスしてください。
+起動後、Webブラウザで http://localhost:5000 にアクセスしてください。
 
 ### **停止・削除コマンド**
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
+from pathlib import Path
 
 
 def _read_int(env_name: str, default: int) -> int:
@@ -21,14 +22,33 @@ class AppConfig:
     gemini_model: str
     max_upload_size: int
     request_timeout: int
+    upload_dir: Path
+    job_history_dir: Path
+    response_history_dir: Path
+    api_key_dir: Path
 
 
 def load_config() -> AppConfig:
     """Load application configuration from the environment."""
     max_upload_size_mb = _read_int("MAX_UPLOAD_SIZE_MB", 15)
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    upload_dir = Path(os.getenv("UPLOAD_DIR", str(data_root / "uploads")))
+    job_history_dir = Path(os.getenv("JOB_HISTORY_DIR", str(data_root / "jobs")))
+    response_history_dir = Path(
+        os.getenv("RESPONSE_HISTORY_DIR", str(data_root / "responses"))
+    )
+    api_key_dir = Path(os.getenv("API_KEY_DIR", str(data_root / "keys")))
+
+    for directory in (upload_dir, job_history_dir, response_history_dir, api_key_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
     return AppConfig(
         gemini_api_key=os.getenv("GEMINI_API_KEY", ""),
         gemini_model=os.getenv("GEMINI_MODEL", "models/gemini-1.5-pro-latest"),
         max_upload_size=max_upload_size_mb * 1024 * 1024,
         request_timeout=_read_int("OCR_REQUEST_TIMEOUT", 300),
+        upload_dir=upload_dir,
+        job_history_dir=job_history_dir,
+        response_history_dir=response_history_dir,
+        api_key_dir=api_key_dir,
     )


### PR DESCRIPTION
## Summary
- change the Docker container to listen on port 5000 and declare bind mount points for user data
- initialise bind-mounted directories through the Flask configuration with environment overrides documented in `.env.example`
- use a BuildKit pip cache during image builds to accelerate dependency installation

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ca198acdb8832d82ea9b8c66b69790