### PR TITLE
Fix docker build compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PORT=5000
 
 COPY backend/requirements.txt ./backend/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r backend/requirements.txt
+RUN pip install -r backend/requirements.txt
 
 COPY backend ./backend
 COPY frontend ./frontend


### PR DESCRIPTION
## Summary
- remove BuildKit-specific pip cache mount from the Dockerfile
- ensure the image can be built by Cloud Build without enabling BuildKit

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ca1e95b69c832d8dbe34f8b139317d