### PR TITLE
Persist uploads and remove API key directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# このファイルを `data/.env` として配置するとコンテナ起動時に読み込まれます
 # Google Gemini API キーを指定してください
 GEMINI_API_KEY=YOUR_GEMINI_API_KEY
 # 利用するモデルを変更したい場合は上書きします
@@ -11,4 +12,3 @@ OCR_REQUEST_TIMEOUT=300
 # UPLOAD_DIR=/data/uploads
 # JOB_HISTORY_DIR=/data/jobs
 # RESPONSE_HISTORY_DIR=/data/responses
-# API_KEY_DIR=/data/keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN pip install -r backend/requirements.txt
 COPY backend ./backend
 COPY frontend ./frontend
 
-RUN mkdir -p /data/uploads /data/jobs /data/responses /data/keys
-VOLUME ["/data/uploads", "/data/jobs", "/data/responses", "/data/keys"]
+RUN mkdir -p /data/uploads /data/jobs /data/responses
+VOLUME ["/data/uploads", "/data/jobs", "/data/responses"]
 
 WORKDIR /app/backend
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Gemini APIを利用して、PDFから以下の項目を抽出します。
 ### **前提条件**
 
 * Docker がインストールされていること。
-* プロジェクトのルートディレクトリに.envファイルを作成し、Gemini APIキーを記述していること。
-  * `cp .env.example .env` でひな形をコピーし、値を編集してください。
-* ユーザーアップロード、ジョブ履歴、応答履歴、APIキーを保存するホスト側ディレクトリを用意し、コンテナの`/data`配下にバインドすること。
-  * 必要に応じて `.env` ファイルで `UPLOAD_DIR` などのパスを上書きできます。
+* コンテナ起動時に読み込む環境変数を `data/.env` に記述していること。
+  * `cp .env.example data/.env` でひな形をコピーし、値を編集してください。
+* ユーザーアップロード、ジョブ履歴、応答履歴を保存するホスト側ディレクトリを用意し、コンテナの`/data`としてバインドすること。
+  * `data` 配下には `uploads`、`jobs`、`responses` ディレクトリを作成してください。必要に応じて `.env` で `UPLOAD_DIR` などのパスを上書きできます。
 
 **.env ファイルの例:**
 
@@ -66,20 +66,18 @@ GEMINI\_API\_KEY="YOUR\_GEMINI\_API\_KEY"
 docker build -t westa-ocr .
 
 \# 永続化ディレクトリの作成
-mkdir -p data/uploads data/jobs data/responses data/keys
+mkdir -p data/uploads data/jobs data/responses
 
 \# コンテナ起動
 docker run \
-  --env-file .env \
-  -v $(pwd)/data/uploads:/data/uploads \
-  -v $(pwd)/data/jobs:/data/jobs \
-  -v $(pwd)/data/responses:/data/responses \
-  -v $(pwd)/data/keys:/data/keys \
+  -v $(pwd)/data:/data \
   -p 5000:5000 \
   --name westa-ocr \
   westa-ocr
 
 起動後、Webブラウザで http://localhost:5000 にアクセスしてください。
+
+アップロードされたファイルはコンテナ内の`/data/uploads`に保存され、バインドマウントされた`data/uploads`ディレクトリから参照できます。`data/.env` に記述した環境変数もコンテナ起動時に自動で読み込まれます。
 
 ### **停止・削除コマンド**
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 
 def _read_int(env_name: str, default: int) -> int:
     raw_value = os.getenv(env_name)
@@ -25,11 +27,18 @@ class AppConfig:
     upload_dir: Path
     job_history_dir: Path
     response_history_dir: Path
-    api_key_dir: Path
+
+def _load_env_from_data_root() -> None:
+    """Load environment variables from `/data/.env` if present."""
+    data_root = Path(os.getenv("DATA_ROOT", "/data"))
+    candidate = data_root / ".env"
+    if candidate.is_file():
+        load_dotenv(candidate, override=False)
 
 
 def load_config() -> AppConfig:
     """Load application configuration from the environment."""
+    _load_env_from_data_root()
     max_upload_size_mb = _read_int("MAX_UPLOAD_SIZE_MB", 15)
     data_root = Path(os.getenv("DATA_ROOT", "/data"))
     upload_dir = Path(os.getenv("UPLOAD_DIR", str(data_root / "uploads")))
@@ -37,9 +46,7 @@ def load_config() -> AppConfig:
     response_history_dir = Path(
         os.getenv("RESPONSE_HISTORY_DIR", str(data_root / "responses"))
     )
-    api_key_dir = Path(os.getenv("API_KEY_DIR", str(data_root / "keys")))
-
-    for directory in (upload_dir, job_history_dir, response_history_dir, api_key_dir):
+    for directory in (upload_dir, job_history_dir, response_history_dir):
         directory.mkdir(parents=True, exist_ok=True)
 
     return AppConfig(
@@ -50,5 +57,4 @@ def load_config() -> AppConfig:
         upload_dir=upload_dir,
         job_history_dir=job_history_dir,
         response_history_dir=response_history_dir,
-        api_key_dir=api_key_dir,
     )


### PR DESCRIPTION
## Summary
- persist uploaded files under the configured uploads directory so they remain available via the data/uploads bind mount
- remove the unused API key storage directory and rely solely on the GEMINI_API_KEY environment variable
- document the updated directory structure and volumes in the README and example environment file
- automatically load environment variables from /data/.env when present so bind-mounted configuration is picked up on boot

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ca3d00a480832db317107d8176f698