### PR TITLE
Update Gemini client integration

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -27,6 +27,7 @@ class AppConfig:
     upload_dir: Path
     job_history_dir: Path
     response_history_dir: Path
+    prompt_template_path: Path
 
 def _load_env_from_data_root() -> None:
     """Load environment variables from `/data/.env` if present."""
@@ -46,15 +47,20 @@ def load_config() -> AppConfig:
     response_history_dir = Path(
         os.getenv("RESPONSE_HISTORY_DIR", str(data_root / "responses"))
     )
+    prompt_template_path = Path(
+        os.getenv("PROMPT_TEMPLATE_PATH", str(data_root / "prompt_template.txt"))
+    )
     for directory in (upload_dir, job_history_dir, response_history_dir):
         directory.mkdir(parents=True, exist_ok=True)
+    prompt_template_path.parent.mkdir(parents=True, exist_ok=True)
 
     return AppConfig(
         gemini_api_key=os.getenv("GEMINI_API_KEY", ""),
-        gemini_model=os.getenv("GEMINI_MODEL", "models/gemini-1.5-pro-latest"),
+        gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-pro"),
         max_upload_size=max_upload_size_mb * 1024 * 1024,
         request_timeout=_read_int("OCR_REQUEST_TIMEOUT", 300),
         upload_dir=upload_dir,
         job_history_dir=job_history_dir,
         response_history_dir=response_history_dir,
+        prompt_template_path=prompt_template_path,
     )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=2.3
 Flask-Cors>=4.0
-google-generativeai>=0.5.0
+google-genai>=1.38.0
 PyPDF2>=3.0
 Pillow>=10.0
 python-dotenv>=1.0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,11 @@
         <div class="offcanvas-body d-flex flex-column">
             <ul class="navbar-nav flex-grow-1 gap-2">
                 <li class="nav-item"><a class="nav-link active" data-bs-dismiss="offcanvas" href="#app"><i class="bi bi-gear-wide-connected me-2"></i>OCR実行</a></li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#" data-bs-dismiss="offcanvas" @click.prevent="openPromptSettings">
+                        <i class="bi bi-sliders me-2"></i>プロンプト設定
+                    </a>
+                </li>
             </ul>
             <div class="small text-muted border-top pt-3">
                 <p class="mb-1"><i class="bi bi-cloud-arrow-up"></i> PDFの自動抽出をさらに効率化。</p>
@@ -143,6 +148,42 @@
         </div>
     </div>
 
+    <div class="modal fade" id="promptSettingsModal" tabindex="-1" aria-labelledby="promptSettingsModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title" id="promptSettingsModalLabel"><i class="bi bi-sliders"></i> プロンプト設定</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="閉じる"></button>
+                </div>
+                <form @submit.prevent="savePromptSettings">
+                    <div class="modal-body">
+                        <div v-if="isPromptLoading" class="d-flex align-items-center justify-content-center py-4 text-muted">
+                            <div class="spinner-border me-3" role="status" aria-hidden="true"></div>
+                            <span>プロンプトを読み込んでいます...</span>
+                        </div>
+                        <div v-else>
+                            <div class="mb-3">
+                                <label for="promptEditor" class="form-label fw-semibold">Gemini への指示内容</label>
+                                <textarea id="promptEditor" class="form-control" rows="10" v-model="promptText" :disabled="isPromptSaving" placeholder="Gemini に渡すプロンプトを入力してください。"></textarea>
+                                <div class="form-text">`{filename}` を差し込むと、アップロードしたファイル名を文中に挿入できます。</div>
+                            </div>
+                            <div v-if="promptFeedback" class="alert" :class="promptFeedback.type === 'success' ? 'alert-success' : 'alert-danger'">
+                                <i :class="promptFeedback.type === 'success' ? 'bi bi-check-circle-fill me-2' : 'bi bi-exclamation-triangle-fill me-2'"></i>{{ promptFeedback.message }}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">閉じる</button>
+                        <button type="submit" class="btn btn-primary" :disabled="isPromptLoading || isPromptSaving">
+                            <span v-if="isPromptSaving" class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                            保存する
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <footer class="bg-white py-4 border-top mt-5">
         <div class="container text-center text-muted small">
             &copy; {{ new Date().getFullYear() }} Gemini OCR Web App
@@ -162,7 +203,11 @@
                     isLoading: false,
                     results: [],
                     errorMessage: '',
-                    apiStatus: null
+                    apiStatus: null,
+                    promptText: '',
+                    isPromptLoading: false,
+                    isPromptSaving: false,
+                    promptFeedback: null
                 };
             },
             methods: {
@@ -241,6 +286,70 @@
                     link.click();
                     document.body.removeChild(link);
                     URL.revokeObjectURL(url);
+                },
+                getPromptModalInstance() {
+                    const modalElement = document.getElementById('promptSettingsModal');
+                    if (!modalElement || !window.bootstrap || !window.bootstrap.Modal) {
+                        return null;
+                    }
+                    return window.bootstrap.Modal.getOrCreateInstance(modalElement);
+                },
+                openPromptSettings(event) {
+                    if (event) {
+                        event.preventDefault();
+                    }
+                    this.promptFeedback = null;
+                    const modal = this.getPromptModalInstance();
+                    if (modal) {
+                        modal.show();
+                    }
+                    this.loadPromptTemplate();
+                },
+                async loadPromptTemplate() {
+                    this.isPromptLoading = true;
+                    try {
+                        const response = await axios.get('/api/prompt');
+                        this.promptText = response.data.prompt || '';
+                    } catch (error) {
+                        console.error('プロンプトの読み込みに失敗しました:', error);
+                        const message = error.response?.data?.error || error.message || 'プロンプトの読み込みに失敗しました。';
+                        this.promptFeedback = {
+                            type: 'error',
+                            message: `読み込みに失敗しました: ${message}`
+                        };
+                    } finally {
+                        this.isPromptLoading = false;
+                    }
+                },
+                async savePromptSettings() {
+                    if (this.isPromptLoading || this.isPromptSaving) {
+                        return;
+                    }
+                    if (!this.promptText || this.promptText.trim() === '') {
+                        this.promptFeedback = {
+                            type: 'error',
+                            message: 'プロンプトを空にすることはできません。'
+                        };
+                        return;
+                    }
+                    this.promptFeedback = null;
+                    this.isPromptSaving = true;
+                    try {
+                        await axios.post('/api/prompt', { prompt: this.promptText });
+                        this.promptFeedback = {
+                            type: 'success',
+                            message: 'プロンプトを更新しました。'
+                        };
+                    } catch (error) {
+                        console.error('プロンプトの保存に失敗しました:', error);
+                        const message = error.response?.data?.error || error.message || 'プロンプトの保存に失敗しました。';
+                        this.promptFeedback = {
+                            type: 'error',
+                            message: `保存に失敗しました: ${message}`
+                        };
+                    } finally {
+                        this.isPromptSaving = false;
+                    }
                 }
             }
         }).mount('#app');


### PR DESCRIPTION
## Summary
- replace the legacy google-generativeai usage with the google-genai client API and structure requests with Content/Part objects
- configure the Gemini request parameters to mirror the provided sample, including thinking config, JSON response type, and request timeout via HttpOptions
- update defaults and dependencies to target the gemini-2.5-pro model
- add persistent prompt template storage with REST endpoints and a navigation modal to edit the prompt from the UI

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ca51720c6c832daf1d3dbfce1ede74