### PR TITLE
Add FastAPI relay service and Docker packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY README.md ./README.md
+
+EXPOSE 8080
+
+ENV SQLITE_PATH=/data/relay.db \
+    TMP_DIR=/data/tmp
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Core application package for the relay service."""
+
+from .main import app  # re-export for convenience when running via `uvicorn app:app`
+
+__all__ = ["app"]

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,50 @@
+"""Request authentication utilities."""
+
+from __future__ import annotations
+
+import hmac
+import time
+from hashlib import sha256
+from fastapi import Depends, HTTPException, Request, status
+
+from .logging_config import get_logger
+from .settings import Settings, get_settings
+
+LOGGER = get_logger(__name__)
+
+
+async def verify_request(request: Request, settings: Settings = Depends(get_settings)) -> None:
+    """Validate incoming requests using Bearer tokens or HMAC signatures."""
+
+    raw_body = await request.body()
+    request._body = raw_body  # type: ignore[attr-defined]
+    request.state.raw_body = raw_body
+
+    if not settings.requires_authentication:
+        return
+
+    auth_header = request.headers.get("Authorization")
+    if auth_header and settings.relay_token:
+        parts = auth_header.split()
+        if len(parts) == 2 and parts[0].lower() == "bearer" and hmac.compare_digest(parts[1], settings.relay_token):
+            return
+
+    signature = request.headers.get("X-Signature")
+    timestamp = request.headers.get("X-Timestamp")
+    if signature and timestamp and settings.hmac_secret:
+        try:
+            ts_int = int(timestamp)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid timestamp") from exc
+        now = int(time.time())
+        if abs(now - ts_int) > settings.hmac_ttl_seconds:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Signature expired")
+        expected = hmac.new(settings.hmac_secret.encode("utf-8"), raw_body, sha256).hexdigest()
+        if hmac.compare_digest(expected, signature):
+            return
+
+    LOGGER.warning("Authentication failed")
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+
+__all__ = ["verify_request"]

--- a/app/file_fetcher.py
+++ b/app/file_fetcher.py
@@ -1,0 +1,57 @@
+"""Utility for retrieving PDF payloads."""
+
+from __future__ import annotations
+
+import httpx
+from pathlib import Path
+from typing import Optional
+
+from .logging_config import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class FileFetcher:
+    """Simple file retriever supporting HTTP(S) and local file paths."""
+
+    def __init__(self, timeout: float) -> None:
+        self._timeout = timeout
+        self._client: Optional[httpx.Client] = None
+
+    def _ensure_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(timeout=self._timeout)
+        return self._client
+
+    def fetch(self, file_id: str) -> bytes:
+        """Fetch a file referenced by ``file_id``."""
+
+        if file_id.startswith("http://") or file_id.startswith("https://"):
+            client = self._ensure_client()
+            LOGGER.info("Fetching file via HTTP", extra={"fileId": file_id})
+            response = client.get(file_id)
+            response.raise_for_status()
+            return response.content
+
+        if file_id.startswith("file://"):
+            path = Path(file_id[7:]).expanduser().resolve()
+            LOGGER.info("Fetching file from local filesystem", extra={"path": str(path)})
+            return path.read_bytes()
+
+        if file_id.startswith("local:"):
+            path = Path(file_id.split(":", 1)[1]).expanduser().resolve()
+            LOGGER.info("Fetching file from local shorthand", extra={"path": str(path)})
+            return path.read_bytes()
+
+        raise ValueError(
+            "Unsupported file identifier. Provide an HTTP(S) URL, file:// path, or "
+            "extend FileFetcher to integrate with Google Drive."
+        )
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+__all__ = ["FileFetcher"]

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,34 @@
+"""Logging configuration utilities."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure root logger with a structured, concise format."""
+
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        # When running under uvicorn there will already be handlers; update their levels instead.
+        for handler in root_logger.handlers:
+            handler.setLevel(level)
+        root_logger.setLevel(level)
+        return
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a module logger."""
+
+    return logging.getLogger(name if name else __name__)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,194 @@
+"""FastAPI application entry-point."""
+
+from __future__ import annotations
+
+import json
+import queue
+import sqlite3
+import secrets
+import string
+from datetime import datetime
+from typing import Dict
+
+from fastapi import Depends, FastAPI, Request, Response, status
+from fastapi.middleware.cors import CORSMiddleware
+
+from .auth import verify_request
+from .file_fetcher import FileFetcher
+from .gemini import GeminiClient
+from .logging_config import configure_logging, get_logger
+from .models import ErrorResponse, JobDetail, JobRequest, JobResponse, JobStatus
+from .repository import JobRepository
+from .settings import get_settings
+from .webhook import WebhookDispatcher
+from .worker import JobWorker
+
+LOGGER = get_logger(__name__)
+
+
+def _generate_job_id() -> str:
+    now = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    suffix = "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(6))
+    return f"job_{now}_{suffix}"
+
+
+def _error_response(code: str, message: str, status_code: int) -> Response:
+    return Response(
+        status_code=status_code,
+        content=json.dumps({"error": {"code": code, "message": message}}, ensure_ascii=False),
+        media_type="application/json",
+    )
+
+
+def create_application() -> FastAPI:
+    settings = get_settings()
+    configure_logging(settings.log_level)
+
+    repository = JobRepository(settings.sqlite_path)
+    job_queue: queue.Queue[str] = queue.Queue()
+    file_fetcher = FileFetcher(settings.request_timeout)
+    gemini_client = GeminiClient(
+        settings.gemini_api_key,
+        default_model=settings.gemini_model,
+        timeout=settings.request_timeout,
+    )
+    webhook_dispatcher = WebhookDispatcher(settings.webhook_timeout)
+    worker = JobWorker(
+        repository=repository,
+        job_queue=job_queue,
+        file_fetcher=file_fetcher,
+        gemini_client=gemini_client,
+        webhook_dispatcher=webhook_dispatcher,
+        idle_sleep=settings.worker_idle_sleep,
+    )
+
+    app = FastAPI(title="westa-ocr relay", version="0.1.0")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.state.settings = settings
+    app.state.repository = repository
+    app.state.job_queue = job_queue
+    app.state.file_fetcher = file_fetcher
+    app.state.gemini_client = gemini_client
+    app.state.webhook_dispatcher = webhook_dispatcher
+    app.state.worker = worker
+
+    register_routes(app)
+    register_events(app)
+
+    return app
+
+
+def register_routes(app: FastAPI) -> None:
+    @app.get("/healthz", tags=["health"])
+    async def healthcheck() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post(
+        "/jobs",
+        response_model=JobResponse,
+        responses={
+            status.HTTP_400_BAD_REQUEST: {"model": ErrorResponse},
+            status.HTTP_401_UNAUTHORIZED: {"model": ErrorResponse},
+            status.HTTP_409_CONFLICT: {"model": ErrorResponse},
+        },
+        tags=["jobs"],
+    )
+    async def create_job(
+        payload: JobRequest,
+        request: Request,
+        _: None = Depends(verify_request),
+    ) -> JobResponse | Response:
+        repository: JobRepository = request.app.state.repository
+        job_queue: queue.Queue[str] = request.app.state.job_queue
+
+        idempotency_key = payload.idempotency_key or payload.order_id
+        existing = repository.find_job_by_idempotency(idempotency_key)
+        if existing:
+            status_value = existing["status"]
+            try:
+                job_status = JobStatus(status_value)
+            except ValueError:  # pragma: no cover - defensive guard
+                job_status = JobStatus.ERROR
+            LOGGER.info(
+                "Job already registered for idempotency key",
+                extra={"jobId": existing["job_id"], "idempotencyKey": idempotency_key},
+            )
+            return JobResponse(
+                job_id=existing["job_id"],
+                correlation_id=existing["order_id"],
+                status=job_status,
+            )
+
+        job_id = _generate_job_id()
+        LOGGER.info("Registering new job", extra={"jobId": job_id, "orderId": payload.order_id})
+        try:
+            repository.insert_job(
+                job_id=job_id,
+                order_id=payload.order_id,
+                file_id=payload.file_id,
+                prompt=payload.prompt,
+                pattern=payload.pattern,
+                masters=payload.masters.model_dump(by_alias=True),
+                webhook=payload.webhook.model_dump(),
+                gemini=payload.gemini.model_dump(by_alias=True, exclude_none=True) if payload.gemini else None,
+                options=payload.options.model_dump(by_alias=True, exclude_none=True) if payload.options else None,
+                idempotency_key=idempotency_key,
+            )
+        except sqlite3.IntegrityError as exc:
+            LOGGER.exception("Integrity error while inserting job", extra={"jobId": job_id})
+            return _error_response("ALREADY_EXISTS", "Job already exists", status.HTTP_409_CONFLICT)
+
+        repository.mark_enqueued(job_id)
+        job_queue.put(job_id)
+        return JobResponse(job_id=job_id, correlation_id=payload.order_id, status=JobStatus.RECEIVED)
+
+    @app.get(
+        "/jobs/{job_id}",
+        response_model=JobDetail,
+        responses={
+            status.HTTP_401_UNAUTHORIZED: {"model": ErrorResponse},
+            status.HTTP_404_NOT_FOUND: {"model": ErrorResponse},
+        },
+        tags=["jobs"],
+    )
+    async def get_job(job_id: str, request: Request, _: None = Depends(verify_request)) -> JobDetail | Response:
+        repository: JobRepository = request.app.state.repository
+        detail = repository.get_job_detail(job_id)
+        if detail is None:
+            return _error_response("NOT_FOUND", "Job not found", status.HTTP_404_NOT_FOUND)
+        return JobDetail(**detail)
+
+
+def register_events(app: FastAPI) -> None:
+    @app.on_event("startup")
+    async def on_startup() -> None:  # pragma: no cover - lifecycle hook
+        repository: JobRepository = app.state.repository
+        job_queue: queue.Queue[str] = app.state.job_queue
+        worker: JobWorker = app.state.worker
+        pending = repository.list_pending_jobs()
+        for job_id in pending:
+            repository.mark_enqueued(job_id)
+            job_queue.put(job_id)
+        worker.start()
+        LOGGER.info("Startup complete", extra={"pendingJobs": len(pending)})
+
+    @app.on_event("shutdown")
+    async def on_shutdown() -> None:  # pragma: no cover - lifecycle hook
+        worker: JobWorker = app.state.worker
+        worker.stop()
+        worker.join(timeout=10)
+
+        app.state.webhook_dispatcher.close()
+        app.state.file_fetcher.close()
+        app.state.gemini_client.close()
+        app.state.repository.close()
+
+
+app = create_application()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,130 @@
+"""Pydantic models and data structures for the relay API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class JobStatus(str, Enum):
+    RECEIVED = "RECEIVED"
+    ENQUEUED = "ENQUEUED"
+    PROCESSING = "PROCESSING"
+    DONE = "DONE"
+    ERROR = "ERROR"
+
+
+class Masters(BaseModel):
+    ship_csv: str = Field(..., alias="shipCsv")
+    item_csv: str = Field(..., alias="itemCsv")
+
+    class Config:
+        populate_by_name = True
+
+
+class WebhookConfig(BaseModel):
+    url: HttpUrl
+    secret: str
+
+
+class GeminiConfig(BaseModel):
+    model: Optional[str] = Field(default=None, description="Gemini model name")
+    temperature: Optional[float] = None
+    topP: Optional[float] = Field(default=None, alias="topP")
+    topK: Optional[int] = Field(default=None, alias="topK")
+    maxOutputTokens: Optional[int] = Field(default=None, alias="maxOutputTokens")
+
+    class Config:
+        populate_by_name = True
+
+
+class JobOptions(BaseModel):
+    split_mode: str = Field(default="pdf", alias="splitMode")
+    dpi: Optional[int] = None
+    concurrency: Optional[int] = None
+
+    class Config:
+        populate_by_name = True
+
+
+class JobRequest(BaseModel):
+    order_id: str = Field(..., alias="orderId")
+    file_id: str = Field(..., alias="fileId")
+    prompt: str
+    pattern: Optional[str] = None
+    masters: Masters
+    webhook: WebhookConfig
+    gemini: Optional[GeminiConfig] = None
+    options: Optional[JobOptions] = None
+    idempotency_key: Optional[str] = Field(default=None, alias="idempotencyKey")
+
+    class Config:
+        populate_by_name = True
+
+
+class JobResponse(BaseModel):
+    job_id: str = Field(..., alias="job_id")
+    correlation_id: str = Field(..., alias="correlation_id")
+    status: JobStatus
+
+
+class ErrorDetail(BaseModel):
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorDetail
+
+
+class PageMeta(BaseModel):
+    model: Optional[str] = None
+    durationMs: Optional[int] = None
+    tokensInput: Optional[int] = None
+    tokensOutput: Optional[int] = None
+
+
+class PageResult(BaseModel):
+    pageIndex: int
+    status: str
+    isNonOrderPage: bool = False
+    rawText: Optional[str] = None
+    error: Optional[str] = None
+    meta: Optional[PageMeta] = None
+
+
+class JobDetail(BaseModel):
+    jobId: str
+    orderId: str
+    status: JobStatus
+    fileId: str
+    prompt: str
+    pattern: Optional[str]
+    masters: Masters
+    webhookUrl: HttpUrl
+    createdAt: datetime
+    updatedAt: datetime
+    totalPages: Optional[int]
+    processedPages: Optional[int]
+    skippedPages: Optional[int]
+    lastError: Optional[str]
+    pages: List[PageResult] = Field(default_factory=list)
+
+
+__all__ = [
+    "ErrorDetail",
+    "ErrorResponse",
+    "GeminiConfig",
+    "JobDetail",
+    "JobOptions",
+    "JobRequest",
+    "JobResponse",
+    "JobStatus",
+    "Masters",
+    "PageMeta",
+    "PageResult",
+    "WebhookConfig",
+]

--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,0 +1,39 @@
+"""PDF and page processing helpers."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import List
+
+from pypdf import PdfReader, PdfWriter
+
+from .logging_config import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class PagePayload:
+    index: int
+    data: bytes
+    mime_type: str
+
+
+def split_pdf(pdf_bytes: bytes) -> List[PagePayload]:
+    """Split a PDF into per-page payloads."""
+
+    buffer = io.BytesIO(pdf_bytes)
+    reader = PdfReader(buffer)
+    pages: List[PagePayload] = []
+    for idx, page in enumerate(reader.pages, start=1):
+        writer = PdfWriter()
+        writer.add_page(page)
+        out_buffer = io.BytesIO()
+        writer.write(out_buffer)
+        pages.append(PagePayload(index=idx, data=out_buffer.getvalue(), mime_type="application/pdf"))
+    LOGGER.info("PDF split into pages", extra={"totalPages": len(pages)})
+    return pages
+
+
+__all__ = ["PagePayload", "split_pdf"]

--- a/app/repository.py
+++ b/app/repository.py
@@ -1,0 +1,327 @@
+"""SQLite-backed persistence utilities."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .logging_config import get_logger
+from .models import JobStatus
+
+LOGGER = get_logger(__name__)
+
+
+class JobRepository:
+    """Data-access layer backed by SQLite."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._path = db_path
+        self._lock = threading.RLock()
+        self._conn = self._connect(db_path)
+        self._initialise()
+
+    @staticmethod
+    def _connect(path: Path) -> sqlite3.Connection:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(path, check_same_thread=False, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA foreign_keys=ON;")
+        return conn
+
+    def _initialise(self) -> None:
+        with self._locked():
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS jobs (
+                    job_id TEXT PRIMARY KEY,
+                    order_id TEXT NOT NULL,
+                    file_id TEXT NOT NULL,
+                    prompt TEXT NOT NULL,
+                    pattern TEXT,
+                    masters_json TEXT NOT NULL,
+                    webhook_url TEXT NOT NULL,
+                    webhook_secret TEXT NOT NULL,
+                    gemini_json TEXT,
+                    options_json TEXT,
+                    idempotency_key TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    last_error TEXT,
+                    total_pages INTEGER,
+                    processed_pages INTEGER,
+                    skipped_pages INTEGER,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(idempotency_key)
+                );
+
+                CREATE TABLE IF NOT EXISTS job_pages (
+                    job_id TEXT NOT NULL,
+                    page_index INTEGER NOT NULL,
+                    status TEXT NOT NULL,
+                    is_non_order_page INTEGER NOT NULL DEFAULT 0,
+                    raw_text TEXT,
+                    error TEXT,
+                    meta_json TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (job_id, page_index),
+                    FOREIGN KEY(job_id) REFERENCES jobs(job_id) ON DELETE CASCADE
+                );
+                """
+            )
+
+    @contextmanager
+    def _locked(self):
+        with self._lock:
+            yield
+
+    def close(self) -> None:
+        with self._locked():
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Job persistence helpers
+    # ------------------------------------------------------------------
+    def insert_job(
+        self,
+        *,
+        job_id: str,
+        order_id: str,
+        file_id: str,
+        prompt: str,
+        pattern: Optional[str],
+        masters: Dict[str, str],
+        webhook: Dict[str, str],
+        gemini: Optional[Dict],
+        options: Optional[Dict],
+        idempotency_key: str,
+    ) -> None:
+        payload = {
+            "job_id": job_id,
+            "order_id": order_id,
+            "file_id": file_id,
+            "prompt": prompt,
+            "pattern": pattern,
+            "masters_json": json.dumps(masters),
+            "webhook_url": webhook["url"],
+            "webhook_secret": webhook["secret"],
+            "gemini_json": json.dumps(gemini) if gemini else None,
+            "options_json": json.dumps(options) if options else None,
+            "idempotency_key": idempotency_key,
+            "status": JobStatus.RECEIVED.value,
+        }
+
+        with self._locked():
+            self._conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, order_id, file_id, prompt, pattern, masters_json,
+                    webhook_url, webhook_secret, gemini_json, options_json,
+                    idempotency_key, status
+                ) VALUES (:job_id, :order_id, :file_id, :prompt, :pattern, :masters_json,
+                          :webhook_url, :webhook_secret, :gemini_json, :options_json,
+                          :idempotency_key, :status)
+                """,
+                payload,
+            )
+
+    def update_job_status(self, job_id: str, status: JobStatus, error: Optional[str] = None) -> None:
+        with self._locked():
+            self._conn.execute(
+                """
+                UPDATE jobs
+                   SET status = ?,
+                       last_error = ?,
+                       updated_at = datetime('now')
+                 WHERE job_id = ?
+                """,
+                (status.value, error, job_id),
+            )
+
+    def update_job_counters(
+        self,
+        job_id: str,
+        *,
+        total_pages: Optional[int],
+        processed_pages: Optional[int],
+        skipped_pages: Optional[int],
+    ) -> None:
+        with self._locked():
+            self._conn.execute(
+                """
+                UPDATE jobs
+                   SET total_pages = ?,
+                       processed_pages = ?,
+                       skipped_pages = ?,
+                       updated_at = datetime('now')
+                 WHERE job_id = ?
+                """,
+                (total_pages, processed_pages, skipped_pages, job_id),
+            )
+
+    def update_job_error(self, job_id: str, error: Optional[str]) -> None:
+        with self._locked():
+            self._conn.execute(
+                """
+                UPDATE jobs
+                   SET last_error = ?,
+                       updated_at = datetime('now')
+                 WHERE job_id = ?
+                """,
+                (error, job_id),
+            )
+
+    def record_page_result(
+        self,
+        job_id: str,
+        page_index: int,
+        *,
+        status: str,
+        is_non_order_page: bool,
+        raw_text: Optional[str],
+        error: Optional[str],
+        meta: Optional[Dict],
+    ) -> None:
+        payload = {
+            "job_id": job_id,
+            "page_index": page_index,
+            "status": status,
+            "is_non_order_page": 1 if is_non_order_page else 0,
+            "raw_text": raw_text,
+            "error": error,
+            "meta_json": json.dumps(meta) if meta else None,
+        }
+        with self._locked():
+            self._conn.execute(
+                """
+                INSERT INTO job_pages (
+                    job_id, page_index, status, is_non_order_page, raw_text, error, meta_json
+                ) VALUES (:job_id, :page_index, :status, :is_non_order_page, :raw_text, :error, :meta_json)
+                ON CONFLICT(job_id, page_index) DO UPDATE SET
+                    status = excluded.status,
+                    is_non_order_page = excluded.is_non_order_page,
+                    raw_text = excluded.raw_text,
+                    error = excluded.error,
+                    meta_json = excluded.meta_json,
+                    updated_at = datetime('now')
+                """,
+                payload,
+            )
+
+    def find_job_by_idempotency(self, key: str) -> Optional[sqlite3.Row]:
+        with self._locked():
+            row = self._conn.execute(
+                "SELECT * FROM jobs WHERE idempotency_key = ?",
+                (key,),
+            ).fetchone()
+        return row
+
+    def get_job(self, job_id: str) -> Optional[sqlite3.Row]:
+        with self._locked():
+            row = self._conn.execute(
+                "SELECT * FROM jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+        return row
+
+    def list_pending_jobs(self) -> List[str]:
+        with self._locked():
+            rows = self._conn.execute(
+                """
+                SELECT job_id
+                  FROM jobs
+                 WHERE status IN (?, ?, ?)
+                 ORDER BY created_at ASC
+                """,
+                (
+                    JobStatus.RECEIVED.value,
+                    JobStatus.ENQUEUED.value,
+                    JobStatus.PROCESSING.value,
+                ),
+            ).fetchall()
+        return [row["job_id"] for row in rows]
+
+    def mark_enqueued(self, job_id: str) -> None:
+        with self._locked():
+            self._conn.execute(
+                """
+                UPDATE jobs
+                   SET status = ?,
+                       updated_at = datetime('now')
+                 WHERE job_id = ?
+                """,
+                (JobStatus.ENQUEUED.value, job_id),
+            )
+
+    def list_page_errors(self, job_id: str) -> List[Dict[str, str]]:
+        with self._locked():
+            rows = self._conn.execute(
+                """
+                SELECT page_index, error
+                  FROM job_pages
+                 WHERE job_id = ? AND error IS NOT NULL
+                """,
+                (job_id,),
+            ).fetchall()
+        return [
+            {"pageIndex": row["page_index"], "message": row["error"]}
+            for row in rows
+        ]
+
+    def list_pages(self, job_id: str) -> List[Dict]:
+        with self._locked():
+            rows = self._conn.execute(
+                """
+                SELECT page_index, status, is_non_order_page, raw_text, error, meta_json
+                  FROM job_pages
+                 WHERE job_id = ?
+                 ORDER BY page_index ASC
+                """,
+                (job_id,),
+            ).fetchall()
+        pages: List[Dict] = []
+        for row in rows:
+            pages.append(
+                {
+                    "pageIndex": row["page_index"],
+                    "status": row["status"],
+                    "isNonOrderPage": bool(row["is_non_order_page"]),
+                    "rawText": row["raw_text"],
+                    "error": row["error"],
+                    "meta": json.loads(row["meta_json"]) if row["meta_json"] else None,
+                }
+            )
+        return pages
+
+    def get_job_detail(self, job_id: str) -> Optional[Dict]:
+        job = self.get_job(job_id)
+        if job is None:
+            return None
+        masters = json.loads(job["masters_json"])
+        detail = {
+            "jobId": job["job_id"],
+            "orderId": job["order_id"],
+            "status": job["status"],
+            "fileId": job["file_id"],
+            "prompt": job["prompt"],
+            "pattern": job["pattern"],
+            "masters": masters,
+            "webhookUrl": job["webhook_url"],
+            "createdAt": datetime.fromisoformat(job["created_at"]),
+            "updatedAt": datetime.fromisoformat(job["updated_at"]),
+            "totalPages": job["total_pages"],
+            "processedPages": job["processed_pages"],
+            "skippedPages": job["skipped_pages"],
+            "lastError": job["last_error"],
+            "pages": self.list_pages(job_id),
+        }
+        return detail
+
+
+__all__ = ["JobRepository"]

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,84 @@
+"""Application settings and configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(slots=True)
+class Settings:
+    """Container for configuration values loaded from environment variables."""
+
+    relay_token: Optional[str]
+    hmac_secret: Optional[str]
+    hmac_ttl_seconds: int
+    sqlite_path: Path
+    data_dir: Path
+    tmp_dir: Path
+    worker_poll_interval: float
+    worker_idle_sleep: float
+    worker_concurrency: int
+    gemini_api_key: Optional[str]
+    gemini_model: str
+    webhook_timeout: float
+    request_timeout: float
+    log_level: str
+
+    @property
+    def requires_authentication(self) -> bool:
+        """Return ``True`` when at least one authentication mechanism is configured."""
+
+        return bool(self.relay_token or self.hmac_secret)
+
+
+def _read_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Environment variable {name} must be a float, got {raw!r}") from exc
+
+
+def _read_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Environment variable {name} must be an integer, got {raw!r}") from exc
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Read and memoise :class:`Settings` from environment variables."""
+
+    data_dir = Path(os.getenv("DATA_DIR", "/data")).resolve()
+    sqlite_path = Path(os.getenv("SQLITE_PATH", str(data_dir / "relay.db"))).resolve()
+    tmp_dir = Path(os.getenv("TMP_DIR", str(data_dir / "tmp"))).resolve()
+
+    return Settings(
+        relay_token=os.getenv("RELAY_TOKEN"),
+        hmac_secret=os.getenv("RELAY_HMAC_SECRET"),
+        hmac_ttl_seconds=_read_int("RELAY_HMAC_TTL", 300),
+        sqlite_path=sqlite_path,
+        data_dir=data_dir,
+        tmp_dir=tmp_dir,
+        worker_poll_interval=_read_float("WORKER_POLL_INTERVAL", 0.5),
+        worker_idle_sleep=_read_float("WORKER_IDLE_SLEEP", 1.0),
+        worker_concurrency=_read_int("WORKER_CONCURRENCY", 3),
+        gemini_api_key=os.getenv("GEMINI_API_KEY"),
+        gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
+        webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),
+        request_timeout=_read_float("REQUEST_TIMEOUT", 60.0),
+        log_level=os.getenv("LOG_LEVEL", "INFO"),
+    )
+
+
+__all__ = ["Settings", "get_settings"]

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -1,0 +1,44 @@
+"""Webhook dispatch utilities."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import time
+from hashlib import sha256
+from typing import Dict
+
+import httpx
+
+from .logging_config import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+class WebhookDispatcher:
+    """Send signed webhook payloads."""
+
+    def __init__(self, timeout: float) -> None:
+        self._client = httpx.Client(timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def send(self, url: str, secret: str, payload: Dict) -> None:
+        raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        timestamp = str(int(time.time()))
+        signature = hmac.new(secret.encode("utf-8"), raw, sha256).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "X-Signature": signature,
+            "X-Timestamp": timestamp,
+        }
+        LOGGER.info(
+            "Dispatching webhook",
+            extra={"url": url, "event": payload.get("event"), "jobId": payload.get("jobId")},
+        )
+        response = self._client.post(url, content=raw, headers=headers)
+        response.raise_for_status()
+
+
+__all__ = ["WebhookDispatcher"]

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,0 +1,241 @@
+"""Background worker implementation."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from typing import Dict, Optional
+
+from .file_fetcher import FileFetcher
+from .gemini import GeminiClient
+from .logging_config import get_logger
+from .models import JobStatus
+from .pdf_utils import PagePayload, split_pdf
+from .repository import JobRepository
+from .webhook import WebhookDispatcher
+
+LOGGER = get_logger(__name__)
+
+
+class JobWorker(threading.Thread):
+    """Threaded worker that processes jobs from the database queue."""
+
+    def __init__(
+        self,
+        *,
+        repository: JobRepository,
+        job_queue: "queue.Queue[str]",
+        file_fetcher: FileFetcher,
+        gemini_client: GeminiClient,
+        webhook_dispatcher: WebhookDispatcher,
+        idle_sleep: float,
+    ) -> None:
+        super().__init__(daemon=True)
+        self._repository = repository
+        self._queue = job_queue
+        self._file_fetcher = file_fetcher
+        self._gemini = gemini_client
+        self._webhook = webhook_dispatcher
+        self._idle_sleep = idle_sleep
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:  # pragma: no cover - threading logic
+        LOGGER.info("Worker thread started")
+        while not self._stop_event.is_set():
+            try:
+                job_id = self._queue.get(timeout=self._idle_sleep)
+            except queue.Empty:
+                continue
+            try:
+                self._process_job(job_id)
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                LOGGER.exception("Unexpected error during job processing", extra={"jobId": job_id})
+                self._repository.update_job_status(job_id, JobStatus.ERROR, str(exc))
+            finally:
+                self._queue.task_done()
+        LOGGER.info("Worker thread stopped")
+
+    def _process_job(self, job_id: str) -> None:
+        job_row = self._repository.get_job(job_id)
+        if job_row is None:
+            LOGGER.warning("Job not found when processing", extra={"jobId": job_id})
+            return
+
+        if job_row["status"] not in (JobStatus.RECEIVED.value, JobStatus.ENQUEUED.value, JobStatus.PROCESSING.value):
+            LOGGER.info("Skipping job in terminal state", extra={"jobId": job_id, "status": job_row["status"]})
+            return
+
+        self._repository.update_job_status(job_id, JobStatus.PROCESSING)
+        LOGGER.info("Processing job", extra={"jobId": job_id, "orderId": job_row["order_id"]})
+        masters = json.loads(job_row["masters_json"])
+        gemini_config = json.loads(job_row["gemini_json"]) if job_row["gemini_json"] else {}
+        options = json.loads(job_row["options_json"]) if job_row["options_json"] else {}
+        split_mode = (options.get("splitMode") or "pdf").lower()
+
+        try:
+            file_bytes = self._file_fetcher.fetch(job_row["file_id"])
+        except Exception as exc:
+            LOGGER.exception("Failed to fetch source file", extra={"jobId": job_id})
+            self._repository.update_job_status(job_id, JobStatus.ERROR, str(exc))
+            self._repository.update_job_counters(job_id, total_pages=None, processed_pages=None, skipped_pages=None)
+            self._send_summary(
+                job_row,
+                total_pages=0,
+                processed_pages=0,
+                skipped_pages=0,
+                errors=[{"message": f"file fetch failed: {exc}"}],
+                status=JobStatus.ERROR,
+            )
+            return
+
+        pages: list[PagePayload]
+        try:
+            if split_mode != "pdf":
+                raise NotImplementedError("Only splitMode=pdf is currently supported")
+            pages = split_pdf(file_bytes)
+        except Exception as exc:
+            LOGGER.exception("Failed to split PDF", extra={"jobId": job_id})
+            self._repository.update_job_status(job_id, JobStatus.ERROR, str(exc))
+            self._repository.update_job_counters(job_id, total_pages=None, processed_pages=None, skipped_pages=None)
+            self._send_summary(
+                job_row,
+                total_pages=0,
+                processed_pages=0,
+                skipped_pages=0,
+                errors=[{"message": f"split failed: {exc}"}],
+                status=JobStatus.ERROR,
+            )
+            return
+
+        total_pages = len(pages)
+        processed_pages = 0
+        page_errors: list[Dict[str, str]] = []
+
+        for page in pages:
+            try:
+                result = self._gemini.generate(
+                    model=gemini_config.get("model"),
+                    prompt=job_row["prompt"],
+                    page_bytes=page.data,
+                    mime_type=page.mime_type,
+                    masters=masters,
+                    temperature=gemini_config.get("temperature"),
+                    top_p=gemini_config.get("topP"),
+                    top_k=gemini_config.get("topK"),
+                    max_output_tokens=gemini_config.get("maxOutputTokens"),
+                )
+                self._repository.record_page_result(
+                    job_id,
+                    page.index,
+                    status="DONE",
+                    is_non_order_page=False,
+                    raw_text=result.text,
+                    error=None,
+                    meta=result.meta,
+                )
+                webhook_error = self._send_page_result(job_row, page.index, result)
+                if webhook_error:
+                    page_errors.append({"pageIndex": page.index, "message": webhook_error})
+                else:
+                    processed_pages += 1
+            except Exception as exc:
+                LOGGER.exception("Failed to process page", extra={"jobId": job_id, "pageIndex": page.index})
+                self._repository.record_page_result(
+                    job_id,
+                    page.index,
+                    status="ERROR",
+                    is_non_order_page=False,
+                    raw_text=None,
+                    error=str(exc),
+                    meta=None,
+                )
+                page_errors.append({"pageIndex": page.index, "message": str(exc)})
+
+        skipped_pages = max(total_pages - processed_pages, 0)
+
+        self._repository.update_job_counters(
+            job_id,
+            total_pages=total_pages,
+            processed_pages=processed_pages,
+            skipped_pages=skipped_pages,
+        )
+
+        if page_errors:
+            summary_status = JobStatus.ERROR
+            self._repository.update_job_status(job_id, JobStatus.ERROR, "; ".join(err["message"] for err in page_errors))
+        else:
+            summary_status = JobStatus.DONE
+            self._repository.update_job_status(job_id, JobStatus.DONE, None)
+
+        self._send_summary(
+            job_row,
+            total_pages=total_pages,
+            processed_pages=processed_pages,
+            skipped_pages=skipped_pages,
+            errors=page_errors,
+            status=summary_status,
+        )
+
+    def _send_page_result(self, job_row, page_index: int, result) -> Optional[str]:
+        payload = {
+            "event": "PAGE_RESULT",
+            "jobId": job_row["job_id"],
+            "orderId": job_row["order_id"],
+            "pageIndex": page_index,
+            "isNonOrderPage": False,
+            "rawText": result.text,
+            "meta": result.meta,
+            "idempotencyKey": f"{job_row['order_id']}:{page_index}",
+        }
+        try:
+            self._webhook.send(job_row["webhook_url"], job_row["webhook_secret"], payload)
+        except Exception as exc:
+            LOGGER.exception(
+                "Failed to dispatch page webhook",
+                extra={"jobId": job_row["job_id"], "pageIndex": page_index},
+            )
+            # Record the failure so that it surfaces in the summary payload.
+            self._repository.record_page_result(
+                job_row["job_id"],
+                page_index,
+                status="ERROR",
+                is_non_order_page=False,
+                raw_text=result.text,
+                error=f"webhook failed: {exc}",
+                meta=result.meta,
+            )
+            return f"webhook failed: {exc}"
+        return None
+
+    def _send_summary(
+        self,
+        job_row,
+        *,
+        total_pages: int,
+        processed_pages: int,
+        skipped_pages: int,
+        errors: list[Dict[str, str]],
+        status: Optional[JobStatus] = None,
+    ) -> None:
+        payload = {
+            "event": "JOB_SUMMARY",
+            "jobId": job_row["job_id"],
+            "orderId": job_row["order_id"],
+            "totalPages": total_pages,
+            "processedPages": processed_pages,
+            "skippedPages": skipped_pages,
+            "errors": errors,
+        }
+        if status is not None:
+            payload["status"] = status.value
+        try:
+            self._webhook.send(job_row["webhook_url"], job_row["webhook_secret"], payload)
+        except Exception as exc:
+            LOGGER.exception("Failed to dispatch summary webhook", extra={"jobId": job_row["job_id"]})
+
+
+__all__ = ["JobWorker"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+httpx>=0.27.0
+pypdf>=4.0.0


### PR DESCRIPTION
## Summary
- build a FastAPI application that registers jobs, secures requests, and exposes health and status endpoints while persisting to SQLite and starting the worker lifecycle
- implement background job execution with file retrieval, PDF splitting, Gemini integration (with a local fallback), and webhook dispatch helpers
- add configuration, authentication, and container packaging including runtime requirements for uvicorn deployment

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cb50941d70832dabf6d7c4891a62ab