### PR TITLE
Switch service port to 5000 and streamline Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.log
+.env
+.git
+.git/*
+.vscode/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
 COPY README.md ./README.md
 
-EXPOSE 8080
+EXPOSE 5000
 
 ENV SQLITE_PATH=/data/relay.db \
     TMP_DIR=/data/tmp
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ signature = hex( HMAC_SHA256(secret, rawRequestBody) )
 
 | env                          | default             | 説明 |
 |-----------------------------|---------------------|------|
-| PORT                        | 8080                | HTTP待受 |
+| PORT                        | 5000                | HTTP待受 |
 | RELAY_TOKEN                 | (必須)              | GAS→Relay の Bearer |
 | WEBHOOK_USER_AGENT          | relay/1.0           | 監査用 UA |
 | GEMINI_API_KEY              | (必須)              | Gemini 認証 |
@@ -301,7 +301,7 @@ workerLoop():
 
 ```bash
 docker run -d --name relay \
-  -p 8080:8080 \
+  -p 5000:5000 \
   -e RELAY_TOKEN="REPLACE_ME" \
   -e GEMINI_API_KEY="REPLACE_ME" \
   -e GEMINI_MODEL="gemini-2.5-flash" \


### PR DESCRIPTION
## Summary
- change the container port exposure and uvicorn startup to use port 5000 by default
- document the new port in the README so runtime instructions stay in sync
- speed up Google Cloud Build executions by dropping the unused apt step and adding a .dockerignore to shrink the build context

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cb55f53704832d9020cdb7774ead37