### PR TITLE
Remove HMAC authentication in favor of bearer token

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import hmac
-import time
-from hashlib import sha256
 from fastapi import Depends, HTTPException, Request, status
 
 from .logging_config import get_logger
@@ -14,33 +12,12 @@ LOGGER = get_logger(__name__)
 
 
 async def verify_request(request: Request, settings: Settings = Depends(get_settings)) -> None:
-    """Validate incoming requests using Bearer tokens or HMAC signatures."""
-
-    raw_body = await request.body()
-    request._body = raw_body  # type: ignore[attr-defined]
-    request.state.raw_body = raw_body
-
-    if not settings.requires_authentication:
-        return
+    """Validate incoming requests using Bearer tokens."""
 
     auth_header = request.headers.get("Authorization")
-    if auth_header and settings.relay_token:
+    if auth_header:
         parts = auth_header.split()
         if len(parts) == 2 and parts[0].lower() == "bearer" and hmac.compare_digest(parts[1], settings.relay_token):
-            return
-
-    signature = request.headers.get("X-Signature")
-    timestamp = request.headers.get("X-Timestamp")
-    if signature and timestamp and settings.hmac_secret:
-        try:
-            ts_int = int(timestamp)
-        except ValueError as exc:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid timestamp") from exc
-        now = int(time.time())
-        if abs(now - ts_int) > settings.hmac_ttl_seconds:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Signature expired")
-        expected = hmac.new(settings.hmac_secret.encode("utf-8"), raw_body, sha256).hexdigest()
-        if hmac.compare_digest(expected, signature):
             return
 
     LOGGER.warning("Authentication failed")

--- a/app/models.py
+++ b/app/models.py
@@ -27,7 +27,6 @@ class Masters(BaseModel):
 
 class WebhookConfig(BaseModel):
     url: HttpUrl
-    secret: str
 
 
 class GeminiConfig(BaseModel):

--- a/app/repository.py
+++ b/app/repository.py
@@ -46,7 +46,6 @@ class JobRepository:
                     pattern TEXT,
                     masters_json TEXT NOT NULL,
                     webhook_url TEXT NOT NULL,
-                    webhook_secret TEXT NOT NULL,
                     gemini_json TEXT,
                     options_json TEXT,
                     idempotency_key TEXT NOT NULL,
@@ -110,7 +109,6 @@ class JobRepository:
             "pattern": pattern,
             "masters_json": json.dumps(masters),
             "webhook_url": webhook["url"],
-            "webhook_secret": webhook["secret"],
             "gemini_json": json.dumps(gemini) if gemini else None,
             "options_json": json.dumps(options) if options else None,
             "idempotency_key": idempotency_key,
@@ -122,10 +120,10 @@ class JobRepository:
                 """
                 INSERT INTO jobs (
                     job_id, order_id, file_id, prompt, pattern, masters_json,
-                    webhook_url, webhook_secret, gemini_json, options_json,
+                    webhook_url, gemini_json, options_json,
                     idempotency_key, status
                 ) VALUES (:job_id, :order_id, :file_id, :prompt, :pattern, :masters_json,
-                          :webhook_url, :webhook_secret, :gemini_json, :options_json,
+                          :webhook_url, :gemini_json, :options_json,
                           :idempotency_key, :status)
                 """,
                 payload,

--- a/app/settings.py
+++ b/app/settings.py
@@ -13,9 +13,7 @@ from typing import Optional
 class Settings:
     """Container for configuration values loaded from environment variables."""
 
-    relay_token: Optional[str]
-    hmac_secret: Optional[str]
-    hmac_ttl_seconds: int
+    relay_token: str
     sqlite_path: Path
     data_dir: Path
     tmp_dir: Path
@@ -27,13 +25,6 @@ class Settings:
     webhook_timeout: float
     request_timeout: float
     log_level: str
-
-    @property
-    def requires_authentication(self) -> bool:
-        """Return ``True`` when at least one authentication mechanism is configured."""
-
-        return bool(self.relay_token or self.hmac_secret)
-
 
 def _read_float(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -63,10 +54,12 @@ def get_settings() -> Settings:
     sqlite_path = Path(os.getenv("SQLITE_PATH", str(data_dir / "relay.db"))).resolve()
     tmp_dir = Path(os.getenv("TMP_DIR", str(data_dir / "tmp"))).resolve()
 
+    relay_token = os.getenv("RELAY_TOKEN")
+    if not relay_token:
+        raise RuntimeError("RELAY_TOKEN environment variable must be set")
+
     return Settings(
-        relay_token=os.getenv("RELAY_TOKEN"),
-        hmac_secret=os.getenv("RELAY_HMAC_SECRET"),
-        hmac_ttl_seconds=_read_int("RELAY_HMAC_TTL", 300),
+        relay_token=relay_token,
         sqlite_path=sqlite_path,
         data_dir=data_dir,
         tmp_dir=tmp_dir,

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import hmac
 import json
-import time
-from hashlib import sha256
 from typing import Dict
 
 import httpx
@@ -16,7 +13,7 @@ LOGGER = get_logger(__name__)
 
 
 class WebhookDispatcher:
-    """Send signed webhook payloads."""
+    """Send webhook payloads."""
 
     def __init__(self, timeout: float) -> None:
         self._client = httpx.Client(timeout=timeout)
@@ -24,14 +21,10 @@ class WebhookDispatcher:
     def close(self) -> None:
         self._client.close()
 
-    def send(self, url: str, secret: str, payload: Dict) -> None:
+    def send(self, url: str, payload: Dict) -> None:
         raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-        timestamp = str(int(time.time()))
-        signature = hmac.new(secret.encode("utf-8"), raw, sha256).hexdigest()
         headers = {
             "Content-Type": "application/json",
-            "X-Signature": signature,
-            "X-Timestamp": timestamp,
         }
         LOGGER.info(
             "Dispatching webhook",

--- a/app/worker.py
+++ b/app/worker.py
@@ -192,7 +192,7 @@ class JobWorker(threading.Thread):
             "idempotencyKey": f"{job_row['order_id']}:{page_index}",
         }
         try:
-            self._webhook.send(job_row["webhook_url"], job_row["webhook_secret"], payload)
+            self._webhook.send(job_row["webhook_url"], payload)
         except Exception as exc:
             LOGGER.exception(
                 "Failed to dispatch page webhook",
@@ -233,7 +233,7 @@ class JobWorker(threading.Thread):
         if status is not None:
             payload["status"] = status.value
         try:
-            self._webhook.send(job_row["webhook_url"], job_row["webhook_secret"], payload)
+            self._webhook.send(job_row["webhook_url"], payload)
         except Exception as exc:
             LOGGER.exception("Failed to dispatch summary webhook", extra={"jobId": job_row["job_id"]})
 


### PR DESCRIPTION
## Summary
- drop HMAC validation from the API and require a relay token configuration at startup
- stop signing webhook payloads and remove storage of webhook secrets
- refresh the README to document the bearer-only flow and simplified webhook headers

## Testing
- RELAY_TOKEN=test pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6bab76b0832da9282c97f1d09a7d