### PR TITLE
Refactor admin console template

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,0 +1,549 @@
+"""Admin dashboard endpoints for manual operations and configuration tweaks."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, Form, Request, status
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from .file_fetcher import FileFetcher
+from .gemini import GeminiClient
+from .logging_config import configure_logging, get_logger
+from .settings import Settings, get_settings
+from .webhook import WebhookDispatcher
+from .worker import JobWorker
+
+LOGGER = get_logger(__name__)
+
+templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+
+
+@dataclass(slots=True)
+class GeminiLogEntry:
+    """Result of a manual Gemini invocation."""
+
+    timestamp: datetime
+    prompt_preview: str
+    model: str
+    mime_type: str
+    success: bool
+    response_text: Optional[str]
+    meta: Optional[Dict]
+    error: Optional[str]
+
+
+@dataclass(slots=True)
+class WebhookLogEntry:
+    """Result of a manual webhook dispatch."""
+
+    timestamp: datetime
+    url: str
+    payload: str
+    success: bool
+    status_code: Optional[int]
+    response_text: Optional[str]
+    error: Optional[str]
+
+
+@dataclass(slots=True)
+class AdminMessage:
+    """Feedback banner to display on the dashboard."""
+
+    timestamp: datetime
+    category: str
+    success: bool
+    summary: str
+    detail: Optional[str]
+
+
+class AdminState:
+    """Container keeping the latest admin operations."""
+
+    def __init__(self) -> None:
+        self._gemini_logs: List[GeminiLogEntry] = []
+        self._webhook_logs: List[WebhookLogEntry] = []
+        self._messages: List[AdminMessage] = []
+
+    @property
+    def gemini_logs(self) -> List[GeminiLogEntry]:
+        return list(self._gemini_logs)
+
+    @property
+    def webhook_logs(self) -> List[WebhookLogEntry]:
+        return list(self._webhook_logs)
+
+    @property
+    def messages(self) -> List[AdminMessage]:
+        return list(self._messages)
+
+    def add_gemini_log(self, entry: GeminiLogEntry) -> None:
+        self._gemini_logs.insert(0, entry)
+        del self._gemini_logs[10:]
+
+    def add_webhook_log(self, entry: WebhookLogEntry) -> None:
+        self._webhook_logs.insert(0, entry)
+        del self._webhook_logs[10:]
+
+    def add_message(self, entry: AdminMessage) -> None:
+        self._messages.insert(0, entry)
+        del self._messages[10:]
+
+
+CONFIG_FIELDS: List[Dict[str, str]] = [
+    {"env": "RELAY_TOKEN", "label": "Relay Token", "placeholder": "必須"},
+    {"env": "DATA_DIR", "label": "Data Directory", "placeholder": "/data"},
+    {"env": "SQLITE_PATH", "label": "SQLite Path", "placeholder": "<DATA_DIR>/relay.db"},
+    {"env": "TMP_DIR", "label": "Temporary Directory", "placeholder": "<DATA_DIR>/tmp"},
+    {"env": "WORKER_POLL_INTERVAL", "label": "Worker Poll Interval", "placeholder": "0.5"},
+    {"env": "WORKER_IDLE_SLEEP", "label": "Worker Idle Sleep", "placeholder": "1.0"},
+    {"env": "WORKER_CONCURRENCY", "label": "Worker Concurrency", "placeholder": "3"},
+    {"env": "GEMINI_API_KEY", "label": "Gemini API Key", "placeholder": ""},
+    {"env": "GEMINI_MODEL", "label": "Gemini Model", "placeholder": "gemini-2.5-flash"},
+    {"env": "WEBHOOK_TIMEOUT", "label": "Webhook Timeout", "placeholder": "30"},
+    {"env": "REQUEST_TIMEOUT", "label": "Request Timeout", "placeholder": "60"},
+    {"env": "LOG_LEVEL", "label": "Log Level", "placeholder": "INFO"},
+]
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _build_dashboard_payload(settings: Settings, state: AdminState) -> Dict[str, Any]:
+    config_fields = []
+    for field in CONFIG_FIELDS:
+        env_name = field["env"]
+        config_fields.append(
+            {
+                "env": env_name,
+                "label": field["label"],
+                "placeholder": field.get("placeholder", ""),
+                "value": os.getenv(env_name, ""),
+                "type": "password"
+                if env_name in {"RELAY_TOKEN", "GEMINI_API_KEY"}
+                else "text",
+            }
+        )
+
+    messages = [
+        {
+            "category": message.category,
+            "success": message.success,
+            "summary": message.summary,
+            "detail": message.detail,
+            "timestamp": _format_datetime(message.timestamp),
+        }
+        for message in state.messages
+    ]
+
+    gemini_logs = [
+        {
+            "timestamp": _format_datetime(entry.timestamp),
+            "promptPreview": entry.prompt_preview,
+            "model": entry.model,
+            "mimeType": entry.mime_type,
+            "success": entry.success,
+            "responseText": entry.response_text,
+            "meta": entry.meta,
+            "error": entry.error,
+        }
+        for entry in state.gemini_logs
+    ]
+
+    webhook_logs = [
+        {
+            "timestamp": _format_datetime(entry.timestamp),
+            "url": entry.url,
+            "payload": entry.payload,
+            "success": entry.success,
+            "statusCode": entry.status_code,
+            "responseText": entry.response_text,
+            "error": entry.error,
+        }
+        for entry in state.webhook_logs
+    ]
+
+    return {
+        "configFields": config_fields,
+        "messages": messages,
+        "geminiLogs": gemini_logs,
+        "webhookLogs": webhook_logs,
+        "defaults": {
+            "mimeType": "text/plain",
+            "masters": "{}",
+            "webhookPayload": "{}",
+            "geminiModel": settings.gemini_model,
+        },
+    }
+
+
+def _parse_optional_float(value: str) -> Optional[float]:
+    value = value.strip()
+    if not value:
+        return None
+    return float(value)
+
+
+def _parse_optional_int(value: str) -> Optional[int]:
+    value = value.strip()
+    if not value:
+        return None
+    return int(value)
+
+
+def _reload_components(app: FastAPI, settings: Settings) -> None:
+    LOGGER.info("Reloading application components via admin console")
+    worker: JobWorker = app.state.worker
+    worker.stop()
+    worker.join(timeout=10)
+
+    file_fetcher: FileFetcher = app.state.file_fetcher
+    gemini_client: GeminiClient = app.state.gemini_client
+    webhook_dispatcher: WebhookDispatcher = app.state.webhook_dispatcher
+
+    file_fetcher.close()
+    gemini_client.close()
+    webhook_dispatcher.close()
+
+    new_file_fetcher = FileFetcher(settings.request_timeout)
+    new_gemini = GeminiClient(
+        settings.gemini_api_key,
+        default_model=settings.gemini_model,
+        timeout=settings.request_timeout,
+    )
+    new_webhook = WebhookDispatcher(settings.webhook_timeout)
+    new_worker = JobWorker(
+        repository=app.state.repository,
+        job_queue=app.state.job_queue,
+        file_fetcher=new_file_fetcher,
+        gemini_client=new_gemini,
+        webhook_dispatcher=new_webhook,
+        idle_sleep=settings.worker_idle_sleep,
+    )
+    new_worker.start()
+
+    app.state.file_fetcher = new_file_fetcher
+    app.state.gemini_client = new_gemini
+    app.state.webhook_dispatcher = new_webhook
+    app.state.worker = new_worker
+
+
+def register_admin_routes(app: FastAPI) -> None:
+    state: AdminState = app.state.admin_state
+
+    @app.get("/admin")
+    async def admin_dashboard(request: Request):
+        settings: Settings = request.app.state.settings
+        payload = _build_dashboard_payload(settings, state)
+        return templates.TemplateResponse("admin.html", {"request": request, "dashboard": payload})
+
+    @app.post("/admin/gemini")
+    async def send_gemini(
+        request: Request,
+        prompt: str = Form(...),
+        input_mode: str = Form("text"),
+        content: str = Form(""),
+        mime_type: str = Form("text/plain"),
+        masters: str = Form("{}"),
+        model: str = Form(""),
+        temperature: str = Form(""),
+        top_p: str = Form(""),
+        top_k: str = Form(""),
+        max_output_tokens: str = Form(""),
+    ) -> RedirectResponse:
+        prompt = prompt.strip()
+        page_content = content.strip()
+        if not prompt:
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="gemini",
+                    success=False,
+                    summary="プロンプトを入力してください",
+                    detail=None,
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+        if not page_content:
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="gemini",
+                    success=False,
+                    summary="入力データを指定してください",
+                    detail=None,
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        try:
+            masters_payload = json.loads(masters) if masters.strip() else {}
+            if not isinstance(masters_payload, dict):
+                raise ValueError("masters must be a JSON object")
+        except Exception as exc:  # pragma: no cover - defensive
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="gemini",
+                    success=False,
+                    summary="マスター情報の読み込みに失敗しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        try:
+            temperature_value = _parse_optional_float(temperature)
+            top_p_value = _parse_optional_float(top_p)
+            top_k_value = _parse_optional_int(top_k)
+            max_tokens_value = _parse_optional_int(max_output_tokens)
+        except ValueError as exc:
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="gemini",
+                    success=False,
+                    summary="数値パラメータの変換に失敗しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        try:
+            if input_mode == "base64":
+                page_bytes = base64.b64decode(page_content, validate=True)
+            else:
+                page_bytes = page_content.encode("utf-8")
+        except Exception as exc:
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="gemini",
+                    success=False,
+                    summary="入力データの変換に失敗しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        gemini_client: GeminiClient = request.app.state.gemini_client
+        try:
+            result = gemini_client.generate(
+                model=model or None,
+                prompt=prompt,
+                page_bytes=page_bytes,
+                mime_type=mime_type or "application/octet-stream",
+                masters=masters_payload,
+                temperature=temperature_value,
+                top_p=top_p_value,
+                top_k=top_k_value,
+                max_output_tokens=max_tokens_value,
+            )
+        except Exception as exc:
+            state.add_gemini_log(
+                GeminiLogEntry(
+                    timestamp=datetime.utcnow(),
+                    prompt_preview=prompt[:80],
+                    model=model or request.app.state.settings.gemini_model,
+                    mime_type=mime_type,
+                    success=False,
+                    response_text=None,
+                    meta=None,
+                    error=str(exc),
+                )
+            )
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="gemini",
+                    success=False,
+                    summary="Gemini へのリクエストでエラーが発生しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        state.add_gemini_log(
+            GeminiLogEntry(
+                timestamp=datetime.utcnow(),
+                prompt_preview=prompt[:80],
+                model=(model or request.app.state.settings.gemini_model),
+                mime_type=mime_type,
+                success=True,
+                response_text=result.text,
+                meta=result.meta,
+                error=None,
+            )
+        )
+        state.add_message(
+            AdminMessage(
+                timestamp=datetime.utcnow(),
+                category="gemini",
+                success=True,
+                summary="Gemini へのリクエストが完了しました",
+                detail=f"モデル: {(model or request.app.state.settings.gemini_model)}",
+            )
+        )
+        return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.post("/admin/webhook")
+    async def send_webhook(
+        request: Request,
+        url: str = Form(...),
+        payload: str = Form(...),
+    ) -> RedirectResponse:
+        try:
+            payload_dict = json.loads(payload)
+            if not isinstance(payload_dict, dict):
+                raise ValueError("payload must be a JSON object")
+        except Exception as exc:
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="webhook",
+                    success=False,
+                    summary="JSON ペイロードの解析に失敗しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        dispatcher: WebhookDispatcher = request.app.state.webhook_dispatcher
+        try:
+            response = dispatcher.send(url, payload_dict)
+            response_text = response.text
+            status_code = response.status_code
+        except Exception as exc:
+            response_text = None
+            status_code = None
+            if hasattr(exc, "response") and exc.response is not None:
+                status_code = exc.response.status_code
+                response_text = exc.response.text
+            state.add_webhook_log(
+                WebhookLogEntry(
+                    timestamp=datetime.utcnow(),
+                    url=url,
+                    payload=payload,
+                    success=False,
+                    status_code=status_code,
+                    response_text=response_text,
+                    error=str(exc),
+                )
+            )
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="webhook",
+                    success=False,
+                    summary="Webhook の送信でエラーが発生しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        state.add_webhook_log(
+            WebhookLogEntry(
+                timestamp=datetime.utcnow(),
+                url=url,
+                payload=json.dumps(payload_dict, ensure_ascii=False, separators=(",", ":")),
+                success=True,
+                status_code=status_code,
+                response_text=response_text,
+                error=None,
+            )
+        )
+        state.add_message(
+            AdminMessage(
+                timestamp=datetime.utcnow(),
+                category="webhook",
+                success=True,
+                summary="Webhook を送信しました",
+                detail=f"HTTP {status_code}",
+            )
+        )
+        return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.post("/admin/settings")
+    async def update_settings(request: Request) -> RedirectResponse:
+        form = await request.form()
+        updates: Dict[str, Optional[str]] = {}
+        for field in CONFIG_FIELDS:
+            env_name = field["env"]
+            raw_value = form.get(env_name)
+            updates[env_name] = raw_value if isinstance(raw_value, str) else None
+
+        if not (updates.get("RELAY_TOKEN") and updates["RELAY_TOKEN"].strip()):
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="settings",
+                    success=False,
+                    summary="Relay Token は必須です",
+                    detail=None,
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        previous_env = {field["env"]: os.getenv(field["env"]) for field in CONFIG_FIELDS}
+
+        def _apply() -> None:
+            for key, value in updates.items():
+                if value is None:
+                    continue
+                stripped = value.strip()
+                if stripped == "":
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = stripped
+
+        def _restore() -> None:
+            for key, value in previous_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        try:
+            _apply()
+            get_settings.cache_clear()
+            new_settings = get_settings()
+        except Exception as exc:
+            _restore()
+            get_settings.cache_clear()
+            restored_settings = get_settings()
+            request.app.state.settings = restored_settings
+            state.add_message(
+                AdminMessage(
+                    timestamp=datetime.utcnow(),
+                    category="settings",
+                    success=False,
+                    summary="環境変数の更新に失敗しました",
+                    detail=str(exc),
+                )
+            )
+            return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+        request.app.state.settings = new_settings
+        configure_logging(new_settings.log_level)
+        _reload_components(request.app, new_settings)
+        state.add_message(
+            AdminMessage(
+                timestamp=datetime.utcnow(),
+                category="settings",
+                success=True,
+                summary="環境変数を更新しました",
+                detail="ワーカーとクライアントを再初期化しました",
+            )
+        )
+        return RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+
+
+__all__ = ["AdminState", "register_admin_routes"]

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from typing import Dict
 from fastapi import Depends, FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 
+from .admin import AdminState, register_admin_routes
 from .auth import verify_request
 from .file_fetcher import FileFetcher
 from .gemini import GeminiClient
@@ -78,8 +79,10 @@ def create_application() -> FastAPI:
     app.state.gemini_client = gemini_client
     app.state.webhook_dispatcher = webhook_dispatcher
     app.state.worker = worker
+    app.state.admin_state = AdminState()
 
     register_routes(app)
+    register_admin_routes(app)
     register_events(app)
 
     return app

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>westa-ocr 管理コンソール</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+  />
+  <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
+  <style>
+    body {
+      background-color: #f8f9fa;
+    }
+    pre {
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .form-text-small {
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body class="bg-light">
+  <div id="app" class="container py-4">
+    <header class="mb-4">
+      <h1 class="h3 mb-1">westa-ocr 管理コンソール</h1>
+      <p class="text-muted mb-0">
+        Gemini への手動リクエスト、Webhook の送信、環境変数の管理を行うツールです。
+      </p>
+    </header>
+
+    <section v-if="state.messages.length" class="mb-4">
+      <div
+        v-for="(message, index) in state.messages"
+        :key="`message-${index}`"
+        class="alert"
+        :class="message.success ? 'alert-success' : 'alert-danger'"
+        role="alert"
+      >
+        <div class="d-flex justify-content-between align-items-start">
+          <div>
+            <span class="badge text-bg-secondary text-uppercase mb-2">[[ message.category ]]</span>
+            <h2 class="h6 mb-1">[[ message.summary ]]</h2>
+            <p class="mb-0" v-if="message.detail">[[ message.detail ]]</p>
+          </div>
+          <small class="text-muted ms-3">[[ message.timestamp ]]</small>
+        </div>
+      </div>
+    </section>
+
+    <div class="row g-4">
+      <div class="col-lg-5">
+        <section class="card shadow-sm h-100">
+          <div class="card-header bg-white">
+            <h2 class="h5 mb-0">環境変数の更新</h2>
+          </div>
+          <div class="card-body">
+            <p class="text-muted form-text-small">
+              空欄にすると既定値が利用されます。Relay Token は必須です。
+            </p>
+            <form method="post" action="/admin/settings">
+              <div class="row g-3">
+                <div
+                  class="col-12"
+                  v-for="field in state.configFields"
+                  :key="field.env"
+                >
+                  <label :for="`settings-${field.env}`" class="form-label">[[ field.label ]]</label>
+                  <input
+                    class="form-control"
+                    :type="field.type"
+                    :id="`settings-${field.env}`"
+                    :name="field.env"
+                    :placeholder="field.placeholder"
+                    v-model="forms.settings[field.env]"
+                    autocomplete="off"
+                  />
+                </div>
+              </div>
+              <div class="d-flex justify-content-end mt-3">
+                <button type="submit" class="btn btn-primary">保存して再読み込み</button>
+              </div>
+            </form>
+          </div>
+        </section>
+      </div>
+      <div class="col-lg-7">
+        <section class="card shadow-sm mb-4">
+          <div class="card-header bg-white">
+            <h2 class="h5 mb-0">Gemini へ手動リクエスト</h2>
+          </div>
+          <div class="card-body">
+            <form method="post" action="/admin/gemini">
+              <div class="mb-3">
+                <label for="gemini-prompt" class="form-label">プロンプト</label>
+                <textarea
+                  id="gemini-prompt"
+                  name="prompt"
+                  class="form-control"
+                  rows="4"
+                  required
+                  v-model="forms.gemini.prompt"
+                ></textarea>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label for="gemini-input-mode" class="form-label">入力データの種類</label>
+                  <select
+                    id="gemini-input-mode"
+                    name="input_mode"
+                    class="form-select"
+                    v-model="forms.gemini.inputMode"
+                  >
+                    <option value="text">テキスト</option>
+                    <option value="base64">Base64</option>
+                  </select>
+                </div>
+                <div class="col-md-6">
+                  <label for="gemini-mime-type" class="form-label">MIME Type</label>
+                  <input
+                    id="gemini-mime-type"
+                    name="mime_type"
+                    type="text"
+                    class="form-control"
+                    v-model="forms.gemini.mimeType"
+                  />
+                </div>
+              </div>
+              <div class="mb-3 mt-3">
+                <label for="gemini-content" class="form-label">入力データ</label>
+                <textarea
+                  id="gemini-content"
+                  name="content"
+                  class="form-control"
+                  rows="5"
+                  v-model="forms.gemini.content"
+                ></textarea>
+              </div>
+              <div class="mb-3">
+                <label for="gemini-masters" class="form-label">マスター情報(JSON)</label>
+                <textarea
+                  id="gemini-masters"
+                  name="masters"
+                  class="form-control"
+                  rows="4"
+                  v-model="forms.gemini.masters"
+                ></textarea>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label for="gemini-model" class="form-label">モデル</label>
+                  <input
+                    id="gemini-model"
+                    name="model"
+                    type="text"
+                    class="form-control"
+                    :placeholder="`既定値: ${state.defaults.geminiModel}`"
+                    v-model="forms.gemini.model"
+                  />
+                </div>
+                <div class="col-md-6">
+                  <label for="gemini-temperature" class="form-label">Temperature</label>
+                  <input
+                    id="gemini-temperature"
+                    name="temperature"
+                    type="text"
+                    class="form-control"
+                    v-model="forms.gemini.temperature"
+                  />
+                </div>
+                <div class="col-md-4">
+                  <label for="gemini-top-p" class="form-label">Top P</label>
+                  <input
+                    id="gemini-top-p"
+                    name="top_p"
+                    type="text"
+                    class="form-control"
+                    v-model="forms.gemini.topP"
+                  />
+                </div>
+                <div class="col-md-4">
+                  <label for="gemini-top-k" class="form-label">Top K</label>
+                  <input
+                    id="gemini-top-k"
+                    name="top_k"
+                    type="text"
+                    class="form-control"
+                    v-model="forms.gemini.topK"
+                  />
+                </div>
+                <div class="col-md-4">
+                  <label for="gemini-max-output" class="form-label">最大出力トークン</label>
+                  <input
+                    id="gemini-max-output"
+                    name="max_output_tokens"
+                    type="text"
+                    class="form-control"
+                    v-model="forms.gemini.maxOutputTokens"
+                  />
+                </div>
+              </div>
+              <div class="d-flex justify-content-end mt-3">
+                <button type="submit" class="btn btn-primary">Gemini へ送信</button>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <section class="card shadow-sm">
+          <div class="card-header bg-white">
+            <h2 class="h5 mb-0">Webhook を手動送信</h2>
+          </div>
+          <div class="card-body">
+            <form method="post" action="/admin/webhook">
+              <div class="mb-3">
+                <label for="webhook-url" class="form-label">URL</label>
+                <input
+                  id="webhook-url"
+                  name="url"
+                  type="url"
+                  class="form-control"
+                  required
+                  v-model="forms.webhook.url"
+                />
+              </div>
+              <div class="mb-3">
+                <label for="webhook-payload" class="form-label">JSON ペイロード</label>
+                <textarea
+                  id="webhook-payload"
+                  name="payload"
+                  class="form-control"
+                  rows="5"
+                  required
+                  v-model="forms.webhook.payload"
+                ></textarea>
+              </div>
+              <div class="d-flex justify-content-end">
+                <button type="submit" class="btn btn-primary">Webhook を送信</button>
+              </div>
+            </form>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <section class="card shadow-sm mt-4">
+      <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Gemini リクエスト履歴</h2>
+        <span class="text-muted small">最大 10 件を表示</span>
+      </div>
+      <div class="card-body">
+        <p class="text-muted mb-0" v-if="!state.geminiLogs.length">履歴はまだありません。</p>
+        <div class="accordion" id="geminiLogs" v-else>
+          <div
+            class="accordion-item"
+            v-for="(log, index) in state.geminiLogs"
+            :key="`gemini-${index}`"
+          >
+            <h2 class="accordion-header" :id="`gemini-heading-${index}`">
+              <button
+                class="accordion-button collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                :data-bs-target="`#gemini-body-${index}`"
+                aria-expanded="false"
+                :aria-controls="`gemini-body-${index}`"
+              >
+                <span class="badge me-3" :class="log.success ? 'text-bg-success' : 'text-bg-danger'">
+                  [[ log.success ? '成功' : '失敗' ]]
+                </span>
+                <span class="me-3 fw-semibold">[[ log.model ]]</span>
+                <span class="me-3 text-muted">[[ log.mimeType ]]</span>
+                <span class="text-muted small">[[ log.timestamp ]]</span>
+              </button>
+            </h2>
+            <div
+              :id="`gemini-body-${index}`"
+              class="accordion-collapse collapse"
+              :aria-labelledby="`gemini-heading-${index}`"
+              data-bs-parent="#geminiLogs"
+            >
+              <div class="accordion-body">
+                <dl class="row mb-0">
+                  <dt class="col-sm-3">プロンプト</dt>
+                  <dd class="col-sm-9">[[ log.promptPreview ]]</dd>
+                  <dt class="col-sm-3">テキスト</dt>
+                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.responseText || '(なし)' ]]</pre></dd>
+                  <dt class="col-sm-3">メタ情報</dt>
+                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ formatJson(log.meta) ]]</pre></dd>
+                  <dt class="col-sm-3">エラー</dt>
+                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.error || '(なし)' ]]</pre></dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card shadow-sm mt-4 mb-5">
+      <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Webhook 履歴</h2>
+        <span class="text-muted small">最大 10 件を表示</span>
+      </div>
+      <div class="card-body">
+        <p class="text-muted mb-0" v-if="!state.webhookLogs.length">履歴はまだありません。</p>
+        <div class="accordion" id="webhookLogs" v-else>
+          <div
+            class="accordion-item"
+            v-for="(log, index) in state.webhookLogs"
+            :key="`webhook-${index}`"
+          >
+            <h2 class="accordion-header" :id="`webhook-heading-${index}`">
+              <button
+                class="accordion-button collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                :data-bs-target="`#webhook-body-${index}`"
+                aria-expanded="false"
+                :aria-controls="`webhook-body-${index}`"
+              >
+                <span class="badge me-3" :class="log.success ? 'text-bg-success' : 'text-bg-danger'">
+                  [[ log.success ? '成功' : '失敗' ]]
+                </span>
+                <span class="me-3 fw-semibold text-break">[[ log.url ]]</span>
+                <span class="text-muted small">HTTP [[ log.statusCode !== null && log.statusCode !== undefined ? log.statusCode : '-' ]]</span>
+                <span class="text-muted small ms-3">[[ log.timestamp ]]</span>
+              </button>
+            </h2>
+            <div
+              :id="`webhook-body-${index}`"
+              class="accordion-collapse collapse"
+              :aria-labelledby="`webhook-heading-${index}`"
+              data-bs-parent="#webhookLogs"
+            >
+              <div class="accordion-body">
+                <dl class="row mb-0">
+                  <dt class="col-sm-3">ペイロード</dt>
+                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.payload ]]</pre></dd>
+                  <dt class="col-sm-3">応答</dt>
+                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.responseText || '(なし)' ]]</pre></dd>
+                  <dt class="col-sm-3">エラー</dt>
+                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.error || '(なし)' ]]</pre></dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const initialState = {{ dashboard | tojson }};
+
+    const app = Vue.createApp({
+      data() {
+        const settings = {};
+        for (const field of initialState.configFields) {
+          settings[field.env] = field.value || '';
+        }
+        return {
+          state: initialState,
+          forms: {
+            settings,
+            gemini: {
+              prompt: '',
+              inputMode: 'text',
+              content: '',
+              mimeType: initialState.defaults.mimeType,
+              masters: initialState.defaults.masters,
+              model: '',
+              temperature: '',
+              topP: '',
+              topK: '',
+              maxOutputTokens: '',
+            },
+            webhook: {
+              url: '',
+              payload: initialState.defaults.webhookPayload,
+            },
+          },
+        };
+      },
+      methods: {
+        formatJson(value) {
+          if (!value) {
+            return '(なし)';
+          }
+          try {
+            return JSON.stringify(value, null, 2);
+          } catch (error) {
+            return String(value);
+          }
+        },
+      },
+    });
+
+    app.config.compilerOptions.delimiters = ['[[', ']]'];
+    app.mount('#app');
+  </script>
+</body>
+</html>

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -21,7 +21,7 @@ class WebhookDispatcher:
     def close(self) -> None:
         self._client.close()
 
-    def send(self, url: str, payload: Dict) -> None:
+    def send(self, url: str, payload: Dict) -> httpx.Response:
         raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
         headers = {
             "Content-Type": "application/json",
@@ -32,6 +32,7 @@ class WebhookDispatcher:
         )
         response = self._client.post(url, content=raw, headers=headers)
         response.raise_for_status()
+        return response
 
 
 __all__ = ["WebhookDispatcher"]


### PR DESCRIPTION
## Summary
- FastAPIベースの管理コンソールをBootstrapとVueを用いたテンプレートに分離し、Gemini手動リクエストやWebhook送信、履歴確認を提供するようにしました
- 管理画面で扱う環境変数や各種履歴データをテンプレートへ渡すためのシリアライザを追加し、既存機能を維持したままUIを刷新しました

## Testing
- python -m compileall app/admin.py app/webhook.py app/main.py


------
https://chatgpt.com/codex/tasks/task_e_68cb95c84188832db3d8725e53800550