### PR TITLE
Use PORT environment variable for uvicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY README.md ./README.md
 EXPOSE 5000
 
 ENV SQLITE_PATH=/data/relay.db \
-    TMP_DIR=/data/tmp
+    TMP_DIR=/data/tmp \
+    PORT=5000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
## Summary
- configure the Docker image to set a default PORT value and use it when starting uvicorn so the service listens on the externally provided port

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb9aa5abbc832d8b6494f9ec116e8b