### PR TITLE
Ensure Gemini requests include master CSV context

### DIFF
--- a/app/gemini.py
+++ b/app/gemini.py
@@ -68,18 +68,27 @@ class GeminiClient:
             )
             return GeminiResult(text=text, meta={"model": target_model, "durationMs": 0, "tokensInput": None, "tokensOutput": None})
 
+        ship_csv = masters.get("shipCsv") if isinstance(masters, dict) else None
+        item_csv = masters.get("itemCsv") if isinstance(masters, dict) else None
+
+        text_segments = [prompt]
+        if ship_csv:
+            text_segments.append(ship_csv)
+        if item_csv:
+            text_segments.append(item_csv)
+
         payload = {
             "contents": [
                 {
                     "role": "user",
                     "parts": [
-                        {"text": prompt},
                         {
                             "inline_data": {
                                 "mime_type": mime_type,
                                 "data": base64.b64encode(page_bytes).decode("utf-8"),
                             }
                         },
+                        {"text": "\n\n".join(text_segments)},
                     ],
                 }
             ],


### PR DESCRIPTION
## Summary
- append the ship and item master CSV content to the Gemini text prompt while keeping the page bytes inline data first
- preserve existing prompt behavior when masters are missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbaa4768b8832d84b4156e0b1bbb93