### PR TITLE
Fix webhook token migration for legacy databases

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,19 @@
 """Core application package for the relay service."""
 
-from .main import app  # re-export for convenience when running via `uvicorn app:app`
+from typing import Any
 
 __all__ = ["app"]
+
+_lazy_app: Any | None = None
+
+
+def __getattr__(name: str) -> Any:
+    if name != "app":
+        raise AttributeError(name)
+
+    global _lazy_app
+    if _lazy_app is None:
+        from .main import app as fastapi_app  # pragma: no cover - exercised indirectly
+
+        _lazy_app = fastapi_app
+    return _lazy_app

--- a/app/repository.py
+++ b/app/repository.py
@@ -83,6 +83,14 @@ class JobRepository:
         columns = {row["name"] for row in cursor.fetchall()}
         if "webhook_token" in columns:
             return
+        if "webhook_secret" in columns:
+            LOGGER.info(
+                "Applying jobs table migration: renaming webhook_secret column to webhook_token"
+            )
+            self._conn.execute(
+                "ALTER TABLE jobs RENAME COLUMN webhook_secret TO webhook_token"
+            )
+            return
         LOGGER.info("Applying jobs table migration: adding webhook_token column")
         self._conn.execute(
             "ALTER TABLE jobs ADD COLUMN webhook_token TEXT NOT NULL DEFAULT ''"

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,3 +1,5 @@
+import json
+import sqlite3
 import sys
 from pathlib import Path
 import os
@@ -58,5 +60,68 @@ def test_insert_job_requires_webhook_token(tmp_path: Path) -> None:
             options=None,
             idempotency_key="order-2",
         )
+
+    repository.close()
+
+
+def test_migration_renames_webhook_secret_column(tmp_path: Path) -> None:
+    db_path = tmp_path / "relay.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            job_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            file_id TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            pattern TEXT,
+            masters_json TEXT NOT NULL,
+            webhook_url TEXT NOT NULL,
+            webhook_secret TEXT NOT NULL,
+            gemini_json TEXT,
+            options_json TEXT,
+            idempotency_key TEXT NOT NULL,
+            status TEXT NOT NULL,
+            last_error TEXT,
+            total_pages INTEGER,
+            processed_pages INTEGER,
+            skipped_pages INTEGER,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(idempotency_key)
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            job_id, order_id, file_id, prompt, pattern, masters_json,
+            webhook_url, webhook_secret, gemini_json, options_json,
+            idempotency_key, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "job_legacy",
+            "legacy-order",
+            "legacy-file",
+            "legacy-prompt",
+            None,
+            json.dumps({"shipCsv": "a", "itemCsv": "b"}),
+            "https://example.com",
+            "legacy-secret",
+            None,
+            None,
+            "legacy-order",
+            "RECEIVED",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    repository = JobRepository(db_path)
+    row = repository.get_job("job_legacy")
+    assert row is not None
+    assert "webhook_token" in row.keys()
+    assert row["webhook_token"] == "legacy-secret"
 
     repository.close()


### PR DESCRIPTION
## Summary
- update the job repository migration to rename legacy webhook_secret columns to webhook_token when needed
- lazily expose the FastAPI app instance to avoid template dependencies during module import
- add regression tests covering webhook token persistence and migration from the legacy schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbac43d060832db785bfc844180a0e