### PR TITLE
Add Google Drive file support

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -362,7 +362,10 @@ def _reload_components(app: FastAPI, settings: Settings) -> None:
     gemini_client.close()
     webhook_dispatcher.close()
 
-    new_file_fetcher = FileFetcher(settings.request_timeout)
+    new_file_fetcher = FileFetcher(
+        settings.request_timeout,
+        drive_service_account_json=settings.drive_service_account_json,
+    )
     new_gemini = GeminiClient(
         settings.gemini_api_key,
         default_model=settings.gemini_model,

--- a/app/file_fetcher.py
+++ b/app/file_fetcher.py
@@ -2,26 +2,106 @@
 
 from __future__ import annotations
 
-import httpx
+import re
 from pathlib import Path
 from typing import Optional
 
+import httpx
+
 from .logging_config import get_logger
+
+try:  # pragma: no cover - optional dependency guard
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+    from google.oauth2 import service_account
+except Exception:  # pragma: no cover - optional dependency guard
+    GoogleAuthRequest = None  # type: ignore
+    service_account = None  # type: ignore
 
 LOGGER = get_logger(__name__)
 
+_DRIVE_FILE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{10,}$")
+_DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+
 
 class FileFetcher:
-    """Simple file retriever supporting HTTP(S) and local file paths."""
+    """Simple file retriever supporting HTTP(S), local paths, and Google Drive."""
 
-    def __init__(self, timeout: float) -> None:
+    def __init__(self, timeout: float, drive_service_account_json: Optional[Path] = None) -> None:
         self._timeout = timeout
         self._client: Optional[httpx.Client] = None
+        self._drive_service_account_json = drive_service_account_json
+        self._drive_credentials = None
+
+        if self._drive_service_account_json and (GoogleAuthRequest is None or service_account is None):
+            raise RuntimeError(
+                "google-auth is required for Google Drive support but is not available"
+            )
 
     def _ensure_client(self) -> httpx.Client:
         if self._client is None:
             self._client = httpx.Client(timeout=self._timeout)
         return self._client
+
+    def _ensure_drive_credentials(self):
+        if not self._drive_service_account_json:
+            return None
+
+        if GoogleAuthRequest is None or service_account is None:
+            raise RuntimeError(
+                "google-auth is required for Google Drive support but is not available"
+            )
+
+        if self._drive_credentials is None:
+            LOGGER.info(
+                "Initialising Google Drive credentials",
+                extra={"credentialsPath": str(self._drive_service_account_json)},
+            )
+            self._drive_credentials = service_account.Credentials.from_service_account_file(  # type: ignore[arg-type]
+                str(self._drive_service_account_json),
+                scopes=[_DRIVE_SCOPE],
+            )
+
+        if not self._drive_credentials.valid:
+            LOGGER.debug("Refreshing Google Drive access token")
+            request = GoogleAuthRequest()
+            self._drive_credentials.refresh(request)
+
+        return self._drive_credentials
+
+    @staticmethod
+    def _normalise_drive_file_id(file_id: str) -> Optional[str]:
+        candidate = file_id.strip()
+        if candidate.startswith("drive://"):
+            candidate = candidate[8:]
+        elif candidate.startswith("drive:"):
+            candidate = candidate.split(":", 1)[1].strip()
+
+        if _DRIVE_FILE_ID_PATTERN.fullmatch(candidate):
+            return candidate
+        return None
+
+    def _fetch_from_drive(self, drive_file_id: str) -> bytes:
+        credentials = self._ensure_drive_credentials()
+        if credentials is None:
+            raise ValueError(
+                "Google Drive credentials not configured. Set DRIVE_SERVICE_ACCOUNT_JSON."
+            )
+
+        if not credentials.token:
+            # Ensure token is available (refresh handles validity above but token may still be None)
+            LOGGER.debug("Refreshing Google Drive token due to missing token")
+            request = GoogleAuthRequest()
+            credentials.refresh(request)
+
+        client = self._ensure_client()
+        LOGGER.info("Fetching file from Google Drive", extra={"fileId": drive_file_id})
+        response = client.get(
+            f"https://www.googleapis.com/drive/v3/files/{drive_file_id}",
+            params={"alt": "media", "supportsAllDrives": "true"},
+            headers={"Authorization": f"Bearer {credentials.token}"},
+        )
+        response.raise_for_status()
+        return response.content
 
     def fetch(self, file_id: str) -> bytes:
         """Fetch a file referenced by ``file_id``."""
@@ -43,9 +123,13 @@ class FileFetcher:
             LOGGER.info("Fetching file from local shorthand", extra={"path": str(path)})
             return path.read_bytes()
 
+        drive_file_id = self._normalise_drive_file_id(file_id)
+        if drive_file_id:
+            return self._fetch_from_drive(drive_file_id)
+
         raise ValueError(
-            "Unsupported file identifier. Provide an HTTP(S) URL, file:// path, or "
-            "extend FileFetcher to integrate with Google Drive."
+            "Unsupported file identifier. Provide an HTTP(S) URL, file:// path, or a valid "
+            "Google Drive file ID."
         )
 
     def close(self) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -47,7 +47,10 @@ def create_application() -> FastAPI:
 
     repository = JobRepository(settings.sqlite_path)
     job_queue: queue.Queue[str] = queue.Queue()
-    file_fetcher = FileFetcher(settings.request_timeout)
+    file_fetcher = FileFetcher(
+        settings.request_timeout,
+        drive_service_account_json=settings.drive_service_account_json,
+    )
     gemini_client = GeminiClient(
         settings.gemini_api_key,
         default_model=settings.gemini_model,

--- a/app/settings.py
+++ b/app/settings.py
@@ -23,6 +23,7 @@ class Settings:
     webhook_timeout: float
     request_timeout: float
     log_level: str
+    drive_service_account_json: Optional[Path]
 
 def _read_float(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -46,6 +47,13 @@ def get_settings() -> Settings:
     if not relay_token:
         raise RuntimeError("RELAY_TOKEN environment variable must be set")
 
+    drive_service_account = os.getenv("DRIVE_SERVICE_ACCOUNT_JSON")
+    drive_service_account_path = (
+        Path(drive_service_account).expanduser().resolve()
+        if drive_service_account
+        else None
+    )
+
     return Settings(
         relay_token=relay_token,
         sqlite_path=sqlite_path,
@@ -57,6 +65,7 @@ def get_settings() -> Settings:
         webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),
         request_timeout=_read_float("REQUEST_TIMEOUT", 60.0),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
+        drive_service_account_json=drive_service_account_path,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ httpx>=0.27.0
 pypdf>=4.0.0
 jinja2>=3.1.0
 python-multipart>=0.0.9
+google-auth>=2.35.0

--- a/tests/test_file_fetcher.py
+++ b/tests/test_file_fetcher.py
@@ -1,0 +1,70 @@
+"""Tests for the :mod:`app.file_fetcher` module."""
+from __future__ import annotations
+import os
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+os.environ.setdefault("RELAY_TOKEN", "test-token")
+
+import pytest
+
+from app.file_fetcher import FileFetcher
+
+
+class DummyResponse:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class DummyClient:
+    def __init__(self, expected_content: bytes) -> None:
+        self._content = expected_content
+        self.requests: list[tuple[str, dict | None, dict | None]] = []
+
+    def get(self, url: str, params=None, headers=None):  # noqa: D401 - simple stub
+        self.requests.append((url, params, headers))
+        return DummyResponse(self._content)
+
+
+class DummyCredentials:
+    def __init__(self, token: str = "token") -> None:
+        self.token = token
+        self.valid = True
+
+    def refresh(self, _request) -> None:  # pragma: no cover - not used in tests
+        self.valid = True
+        self.token = "token"
+
+
+def test_fetch_drive_requires_credentials() -> None:
+    fetcher = FileFetcher(timeout=1.0, drive_service_account_json=None)
+    with pytest.raises(ValueError) as exc:
+        fetcher.fetch("1A2B3C4D5E6F7G8H9I0J")
+    assert "Google Drive" in str(exc.value)
+
+
+def test_fetch_drive_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetcher = FileFetcher(timeout=1.0, drive_service_account_json=None)
+
+    dummy_client = DummyClient(b"content")
+    monkeypatch.setattr(fetcher, "_ensure_client", lambda: dummy_client)
+    monkeypatch.setattr(fetcher, "_ensure_drive_credentials", lambda: DummyCredentials())
+
+    # Pretend that credentials are configured so the Drive branch is used
+    fetcher._drive_service_account_json = Path("dummy.json")  # type: ignore[attr-defined]
+
+    result = fetcher.fetch("drive:1A2B3C4D5E6F7G8H9I0J")
+
+    assert result == b"content"
+    assert dummy_client.requests
+    url, params, headers = dummy_client.requests[0]
+    assert url.endswith("/1A2B3C4D5E6F7G8H9I0J")
+    assert params == {"alt": "media", "supportsAllDrives": "true"}
+    assert headers["Authorization"].startswith("Bearer ")


### PR DESCRIPTION
## Summary
- extend FileFetcher to download PDFs from Google Drive using a service account token
- expose DRIVE_SERVICE_ACCOUNT_JSON in settings and wire it through app initialization and admin reload flows
- add google-auth dependency and tests covering Google Drive identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbba600be0832db2d2ac165adaeb25