### PR TITLE
Add Google Drive client dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ pypdf>=4.0.0
 jinja2>=3.1.0
 python-multipart>=0.0.9
 google-auth>=2.35.0
+google-api-python-client>=2.149.0
+google-auth-httplib2>=0.2.0
+httplib2>=0.22.0


### PR DESCRIPTION
## Summary
- add Google Drive related Google API client dependencies to requirements

## Testing
- pip install -r requirements.txt
- python -c "import googleapiclient.discovery, google_auth_httplib2, httplib2"


------
https://chatgpt.com/codex/tasks/task_e_68cbd6db81c4832d8a929679d8a51918