### PR TITLE
Persist Gemini request logs to SQLite and surface in admin UI

### DIFF
--- a/app/gemini.py
+++ b/app/gemini.py
@@ -39,6 +39,10 @@ class GeminiClient:
             self._client.close()
             self._client = None
 
+    @property
+    def default_model(self) -> str:
+        return self._default_model
+
     def generate(
         self,
         *,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -389,7 +389,7 @@
           <div
             class="accordion-item"
             v-for="(log, index) in state.geminiLogs"
-            :key="`gemini-${index}`"
+            :key="`gemini-${log.id}`"
           >
             <h2 class="accordion-header" :id="`gemini-heading-${index}`">
               <button
@@ -403,6 +403,7 @@
                 <span class="badge me-3" :class="log.success ? 'text-bg-success' : 'text-bg-danger'">
                   [[ log.success ? '成功' : '失敗' ]]
                 </span>
+                <span class="badge text-bg-secondary me-3">[[ log.sourceLabel ]]</span>
                 <span class="me-3 fw-semibold">[[ log.model ]]</span>
                 <span class="me-3 text-muted">[[ log.mimeType ]]</span>
                 <span class="text-muted small">[[ log.timestamp ]]</span>
@@ -413,16 +414,20 @@
               class="accordion-collapse collapse"
               :aria-labelledby="`gemini-heading-${index}`"
               data-bs-parent="#geminiLogs"
-            >
-              <div class="accordion-body">
-                <dl class="row mb-0">
-                  <dt class="col-sm-3">プロンプト</dt>
-                  <dd class="col-sm-9">[[ log.promptPreview ]]</dd>
-                  <dt class="col-sm-3">テキスト</dt>
-                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.responseText || '(なし)' ]]</pre></dd>
-                  <dt class="col-sm-3">メタ情報</dt>
-                  <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ formatJson(log.meta) ]]</pre></dd>
-                  <dt class="col-sm-3">エラー</dt>
+              >
+                <div class="accordion-body">
+                  <dl class="row mb-0">
+                    <dt class="col-sm-3">ソース</dt>
+                    <dd class="col-sm-9">[[ log.source ]]</dd>
+                    <dt class="col-sm-3">プロンプト</dt>
+                    <dd class="col-sm-9">[[ log.promptPreview ]]</dd>
+                    <dt class="col-sm-3">リクエスト</dt>
+                    <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ formatJson(log.request) ]]</pre></dd>
+                    <dt class="col-sm-3">テキスト</dt>
+                    <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.responseText || '(なし)' ]]</pre></dd>
+                    <dt class="col-sm-3">メタ情報</dt>
+                    <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ formatJson(log.meta) ]]</pre></dd>
+                    <dt class="col-sm-3">エラー</dt>
                   <dd class="col-sm-9"><pre class="bg-light p-3 rounded">[[ log.error || '(なし)' ]]</pre></dd>
                 </dl>
               </div>


### PR DESCRIPTION
## Summary
- add a SQLite-backed gemini_logs table and repository helpers for storing Gemini requests and responses
- persist manual and worker Gemini interactions to the new store and expose detailed history in the admin console
- update automated tests to cover the new logging capabilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca40985a0832d86aa41d9a3809280