### PR TITLE
Add configurable worker pool for parallel job processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ GAS(doPost) で検証・保存・集計
 - **FileFetcher**: `http(s)://`、`file://`、`local:`、および Google Drive のファイル ID に対応。Drive 利用時はサービスアカウント認証（`DRIVE_SERVICE_ACCOUNT_JSON`）を読み込み、必要に応じてトークンをリフレッシュする。
 - **GeminiClient**: `models/{model}:generateContent` を呼び出し、ページ PDF・プロンプト・マスタ CSV を 1 リクエストにまとめる。API キー未設定時はシミュレーションレスポンスを返すので、ローカル検証が容易。
 - **WebhookDispatcher**: Apps Script など 302 を返すエンドポイントにも対応できるよう `follow_redirects=True` で POST。Bearer トークンを自動付与し、失敗時は例外で呼び出し元に通知する。
-- **JobWorker**: 1 スレッドで順次処理し、ページ結果を都度 SQLite と Webhook に記録。途中失敗時は `_handle_initial_failure` でサマリを送信し、ジョブを `ERROR` として終了させる。
+- **JobWorker**: 指定したスレッド数だけ起動され、キューからジョブを取り出して並列に処理する。ページ結果は都度 SQLite と Webhook に記録し、途中失敗時は `_handle_initial_failure` でサマリを送信してジョブを `ERROR` として終了させる。
 
 ---
 
@@ -203,6 +203,7 @@ GAS(doPost) で検証・保存・集計
 | SQLITE_PATH               | `/data/relay.db`   | SQLite ファイルパス |
 | TMP_DIR                   | `/data/tmp`        | 予約（現状未使用） |
 | WORKER_IDLE_SLEEP         | `1.0`              | ワーカーがキュー待機するときの sleep 秒数 |
+| WORKER_COUNT              | `1`                | 並列実行するジョブワーカーのスレッド数 |
 | GEMINI_API_KEY            | なし               | 未設定だとシミュレーション動作 |
 | GEMINI_MODEL              | `gemini-2.5-flash` | 既定モデル名 |
 | WEBHOOK_TIMEOUT           | `30.0`             | Webhook POST タイムアウト（秒） |


### PR DESCRIPTION
## Summary
- add a `WORKER_COUNT` setting that validates integer input
- start and manage multiple `JobWorker` threads across startup, shutdown, and admin reloads
- document the new parallel worker behaviour and configuration option

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccabd9a9f4832db357b358e7b74902