### PR TITLE
Add admin job cancellation controls and adjust timeouts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -15,6 +15,7 @@ class JobStatus(str, Enum):
     PROCESSING = "PROCESSING"
     DONE = "DONE"
     ERROR = "ERROR"
+    CANCELLED = "CANCELLED"
 
 
 class Masters(BaseModel):

--- a/app/settings.py
+++ b/app/settings.py
@@ -75,11 +75,11 @@ def get_settings() -> Settings:
         data_dir=data_dir,
         tmp_dir=tmp_dir,
         worker_idle_sleep=_read_float("WORKER_IDLE_SLEEP", 1.0),
-        worker_count=_read_int("WORKER_COUNT", 1, minimum=1),
+        worker_count=_read_int("WORKER_COUNT", 10, minimum=1),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
         gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
         webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),
-        request_timeout=_read_float("REQUEST_TIMEOUT", 60.0),
+        request_timeout=_read_float("REQUEST_TIMEOUT", 600.0),
         log_level=os.getenv("LOG_LEVEL", "INFO"),
         drive_service_account_json=drive_service_account_path,
     )

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -269,6 +269,61 @@
 
     <section class="card shadow-sm mt-4">
       <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">ジョブ状況</h2>
+        <span class="text-muted small">最新 20 件を表示</span>
+      </div>
+      <div class="card-body">
+        <p class="text-muted mb-0" v-if="!state.jobs.length">ジョブ履歴はまだありません。</p>
+        <div class="table-responsive" v-else>
+          <table class="table table-sm align-middle">
+            <thead>
+              <tr>
+                <th scope="col">Job ID</th>
+                <th scope="col">Order ID</th>
+                <th scope="col">ステータス</th>
+                <th scope="col">ページ進捗</th>
+                <th scope="col">更新日時</th>
+                <th scope="col">最終エラー</th>
+                <th scope="col" class="text-center">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="job in state.jobs" :key="job.jobId">
+                <td class="text-break"><code>[[ job.jobId ]]</code></td>
+                <td class="text-break">[[ job.orderId ]]</td>
+                <td><span class="badge text-bg-secondary">[[ job.statusLabel ]]</span></td>
+                <td>
+                  [[ job.processedPages !== null && job.totalPages !== null
+                    ? job.processedPages + ' / ' + job.totalPages + (job.skippedPages !== null ? ' (skip ' + job.skippedPages + ')' : '')
+                    : '-' ]]
+                </td>
+                <td>
+                  <div>作成 [[ job.createdAt ]]</div>
+                  <div>更新 [[ job.updatedAt ]]</div>
+                </td>
+                <td class="text-break">[[ job.lastError || '-' ]]</td>
+                <td class="text-center">
+                  <form
+                    v-if="job.canCancel"
+                    method="post"
+                    action="/admin/jobs/cancel"
+                    class="d-inline"
+                  >
+                    <input type="hidden" name="job_id" :value="job.jobId" />
+                    <button type="submit" class="btn btn-outline-danger btn-sm">中断</button>
+                  </form>
+                  <span v-else-if="job.cancellationRequested" class="badge text-bg-warning">中断要求中</span>
+                  <span v-else>-</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="card shadow-sm mt-4">
+      <div class="card-header bg-white d-flex justify-content-between align-items-center">
         <h2 class="h5 mb-0">ProcessOrder_test_relay リクエスト履歴</h2>
         <span class="text-muted small">最大 50 件を表示</span>
       </div>

--- a/app/worker.py
+++ b/app/worker.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:  # pragma: no cover - typing helper
 
 LOGGER = get_logger(__name__)
 
+CANCEL_REASON = "Cancelled via admin console"
+
 
 class JobWorker(threading.Thread):
     """Threaded worker that processes jobs from the database queue."""
@@ -66,161 +68,234 @@ class JobWorker(threading.Thread):
         LOGGER.info("Worker thread stopped", extra={"threadName": self.name})
 
     def _process_job(self, job_id: str) -> None:
-        job_row = self._repository.get_job(job_id)
-        if job_row is None:
-            LOGGER.warning("Job not found when processing", extra={"jobId": job_id})
-            return
-
-        if job_row["status"] not in (JobStatus.RECEIVED.value, JobStatus.ENQUEUED.value, JobStatus.PROCESSING.value):
-            LOGGER.info("Skipping job in terminal state", extra={"jobId": job_id, "status": job_row["status"]})
-            return
-
-        self._repository.update_job_status(job_id, JobStatus.PROCESSING)
-        LOGGER.info("Processing job", extra={"jobId": job_id, "orderId": job_row["order_id"]})
-        masters = json.loads(job_row["masters_json"])
-        gemini_config = json.loads(job_row["gemini_json"]) if job_row["gemini_json"] else {}
-        options = json.loads(job_row["options_json"]) if job_row["options_json"] else {}
-        split_mode = (options.get("splitMode") or "pdf").lower()
-
         try:
-            file_bytes = self._file_fetcher.fetch(job_row["file_id"])
-        except Exception as exc:
-            self._handle_initial_failure(
-                job_row,
-                job_id,
-                log_message="Failed to fetch source file",
-                error_prefix="file fetch failed",
-                exc=exc,
-            )
-            return
+            job_row = self._repository.get_job(job_id)
+            if job_row is None:
+                LOGGER.warning("Job not found when processing", extra={"jobId": job_id})
+                return
 
-        pages: list[PagePayload]
-        try:
-            if split_mode != "pdf":
-                raise NotImplementedError("Only splitMode=pdf is currently supported")
-            pages = split_pdf(file_bytes)
-        except Exception as exc:
-            self._handle_initial_failure(
-                job_row,
-                job_id,
-                log_message="Failed to split PDF",
-                error_prefix="split failed",
-                exc=exc,
-            )
-            return
+            if job_row["status"] not in (
+                JobStatus.RECEIVED.value,
+                JobStatus.ENQUEUED.value,
+                JobStatus.PROCESSING.value,
+            ):
+                LOGGER.info(
+                    "Skipping job in terminal state",
+                    extra={"jobId": job_id, "status": job_row["status"]},
+                )
+                return
 
-        total_pages = len(pages)
-        processed_pages = 0
-        page_errors: list[Dict[str, str]] = []
+            if self._is_cancellation_requested(job_id):
+                LOGGER.info("Skipping job that was cancelled before processing", extra={"jobId": job_id})
+                self._repository.update_job_status(job_id, JobStatus.CANCELLED, CANCEL_REASON)
+                return
 
-        for page in pages:
-            target_model = gemini_config.get("model") or self._gemini.default_model
-            request_snapshot = {
-                "jobId": job_row["job_id"],
-                "orderId": job_row["order_id"],
-                "pageIndex": page.index,
-                "prompt": job_row["prompt"],
-                "promptLength": len(job_row["prompt"]),
-                "masters": masters,
-                "mastersKeys": sorted(masters.keys()),
-                "input": {
-                    "mode": "pdf_page",
-                    "mimeType": page.mime_type,
-                    "sizeBytes": len(page.data),
-                },
-                "parameters": {
-                    "model": target_model,
-                    "temperature": gemini_config.get("temperature"),
-                    "topP": gemini_config.get("topP"),
-                    "topK": gemini_config.get("topK"),
-                    "maxOutputTokens": gemini_config.get("maxOutputTokens"),
-                },
-            }
+            self._repository.update_job_status(job_id, JobStatus.PROCESSING)
+            LOGGER.info("Processing job", extra={"jobId": job_id, "orderId": job_row["order_id"]})
+            masters = json.loads(job_row["masters_json"])
+            gemini_config = json.loads(job_row["gemini_json"]) if job_row["gemini_json"] else {}
+            options = json.loads(job_row["options_json"]) if job_row["options_json"] else {}
+            split_mode = (options.get("splitMode") or "pdf").lower()
+
             try:
-                result = self._gemini.generate(
-                    model=gemini_config.get("model"),
-                    prompt=job_row["prompt"],
-                    page_bytes=page.data,
-                    mime_type=page.mime_type,
-                    masters=masters,
-                    temperature=gemini_config.get("temperature"),
-                    top_p=gemini_config.get("topP"),
-                    top_k=gemini_config.get("topK"),
-                    max_output_tokens=gemini_config.get("maxOutputTokens"),
-                )
-                self._repository.record_gemini_log(
-                    source="worker",
-                    prompt=job_row["prompt"],
-                    model=target_model,
-                    mime_type=page.mime_type,
-                    request=request_snapshot,
-                    success=True,
-                    response_text=result.text,
-                    meta=result.meta,
-                    error=None,
-                )
-                self._repository.record_page_result(
-                    job_id,
-                    page.index,
-                    status="DONE",
-                    is_non_order_page=False,
-                    raw_text=result.text,
-                    error=None,
-                    meta=result.meta,
-                )
-                webhook_error = self._send_page_result(job_row, page.index, result)
-                if webhook_error:
-                    page_errors.append({"pageIndex": page.index, "message": webhook_error})
-                else:
-                    processed_pages += 1
+                file_bytes = self._file_fetcher.fetch(job_row["file_id"])
             except Exception as exc:
-                self._repository.record_gemini_log(
-                    source="worker",
-                    prompt=job_row["prompt"],
-                    model=target_model,
-                    mime_type=page.mime_type,
-                    request=request_snapshot,
-                    success=False,
-                    response_text=None,
-                    meta=None,
-                    error=str(exc),
-                )
-                LOGGER.exception("Failed to process page", extra={"jobId": job_id, "pageIndex": page.index})
-                self._repository.record_page_result(
+                self._handle_initial_failure(
+                    job_row,
                     job_id,
-                    page.index,
-                    status="ERROR",
-                    is_non_order_page=False,
-                    raw_text=None,
-                    error=str(exc),
-                    meta=None,
+                    log_message="Failed to fetch source file",
+                    error_prefix="file fetch failed",
+                    exc=exc,
                 )
-                page_errors.append({"pageIndex": page.index, "message": str(exc)})
+                return
 
+            pages: list[PagePayload]
+            try:
+                if split_mode != "pdf":
+                    raise NotImplementedError("Only splitMode=pdf is currently supported")
+                pages = split_pdf(file_bytes)
+            except Exception as exc:
+                self._handle_initial_failure(
+                    job_row,
+                    job_id,
+                    log_message="Failed to split PDF",
+                    error_prefix="split failed",
+                    exc=exc,
+                )
+                return
+
+            total_pages = len(pages)
+            processed_pages = 0
+            page_errors: list[Dict[str, str]] = []
+
+            for page in pages:
+                if self._is_cancellation_requested(job_id):
+                    LOGGER.info(
+                        "Cancellation detected during page loop",
+                        extra={"jobId": job_id, "pageIndex": page.index},
+                    )
+                    self._handle_job_cancellation(
+                        job_row,
+                        total_pages,
+                        processed_pages,
+                        page_errors,
+                    )
+                    return
+
+                target_model = gemini_config.get("model") or self._gemini.default_model
+                request_snapshot = {
+                    "jobId": job_row["job_id"],
+                    "orderId": job_row["order_id"],
+                    "pageIndex": page.index,
+                    "prompt": job_row["prompt"],
+                    "promptLength": len(job_row["prompt"]),
+                    "masters": masters,
+                    "mastersKeys": sorted(masters.keys()),
+                    "input": {
+                        "mode": "pdf_page",
+                        "mimeType": page.mime_type,
+                        "sizeBytes": len(page.data),
+                    },
+                    "parameters": {
+                        "model": target_model,
+                        "temperature": gemini_config.get("temperature"),
+                        "topP": gemini_config.get("topP"),
+                        "topK": gemini_config.get("topK"),
+                        "maxOutputTokens": gemini_config.get("maxOutputTokens"),
+                    },
+                }
+                try:
+                    result = self._gemini.generate(
+                        model=gemini_config.get("model"),
+                        prompt=job_row["prompt"],
+                        page_bytes=page.data,
+                        mime_type=page.mime_type,
+                        masters=masters,
+                        temperature=gemini_config.get("temperature"),
+                        top_p=gemini_config.get("topP"),
+                        top_k=gemini_config.get("topK"),
+                        max_output_tokens=gemini_config.get("maxOutputTokens"),
+                    )
+                    self._repository.record_gemini_log(
+                        source="worker",
+                        prompt=job_row["prompt"],
+                        model=target_model,
+                        mime_type=page.mime_type,
+                        request=request_snapshot,
+                        success=True,
+                        response_text=result.text,
+                        meta=result.meta,
+                        error=None,
+                    )
+                    self._repository.record_page_result(
+                        job_id,
+                        page.index,
+                        status="DONE",
+                        is_non_order_page=False,
+                        raw_text=result.text,
+                        error=None,
+                        meta=result.meta,
+                    )
+                    webhook_error = self._send_page_result(job_row, page.index, result)
+                    if webhook_error:
+                        page_errors.append({"pageIndex": page.index, "message": webhook_error})
+                    else:
+                        processed_pages += 1
+                except Exception as exc:
+                    self._repository.record_gemini_log(
+                        source="worker",
+                        prompt=job_row["prompt"],
+                        model=target_model,
+                        mime_type=page.mime_type,
+                        request=request_snapshot,
+                        success=False,
+                        response_text=None,
+                        meta=None,
+                        error=str(exc),
+                    )
+                    LOGGER.exception(
+                        "Failed to process page", extra={"jobId": job_id, "pageIndex": page.index}
+                    )
+                    self._repository.record_page_result(
+                        job_id,
+                        page.index,
+                        status="ERROR",
+                        is_non_order_page=False,
+                        raw_text=None,
+                        error=str(exc),
+                        meta=None,
+                    )
+                    page_errors.append({"pageIndex": page.index, "message": str(exc)})
+
+            if self._is_cancellation_requested(job_id):
+                LOGGER.info("Cancellation detected before summary", extra={"jobId": job_id})
+                self._handle_job_cancellation(job_row, total_pages, processed_pages, page_errors)
+                return
+
+            skipped_pages = max(total_pages - processed_pages, 0)
+
+            self._repository.update_job_counters(
+                job_id,
+                total_pages=total_pages,
+                processed_pages=processed_pages,
+                skipped_pages=skipped_pages,
+            )
+
+            if page_errors:
+                summary_status = JobStatus.ERROR
+                self._repository.update_job_status(
+                    job_id, JobStatus.ERROR, "; ".join(err["message"] for err in page_errors)
+                )
+            else:
+                summary_status = JobStatus.DONE
+                self._repository.update_job_status(job_id, JobStatus.DONE, None)
+
+            self._send_summary(
+                job_row,
+                total_pages=total_pages,
+                processed_pages=processed_pages,
+                skipped_pages=skipped_pages,
+                errors=page_errors,
+                status=summary_status,
+            )
+        finally:
+            self._clear_cancellation_flag(job_id)
+
+    def _is_cancellation_requested(self, job_id: str) -> bool:
+        if self._admin_state and self._admin_state.is_cancellation_requested(job_id):
+            return True
+        status = self._repository.get_job_status(job_id)
+        return status == JobStatus.CANCELLED.value
+
+    def _handle_job_cancellation(
+        self,
+        job_row,
+        total_pages: int,
+        processed_pages: int,
+        page_errors: list[Dict[str, str]],
+    ) -> None:
         skipped_pages = max(total_pages - processed_pages, 0)
-
+        errors = list(page_errors)
+        errors.append({"message": "Cancelled via admin console"})
         self._repository.update_job_counters(
-            job_id,
+            job_row["job_id"],
             total_pages=total_pages,
             processed_pages=processed_pages,
             skipped_pages=skipped_pages,
         )
-
-        if page_errors:
-            summary_status = JobStatus.ERROR
-            self._repository.update_job_status(job_id, JobStatus.ERROR, "; ".join(err["message"] for err in page_errors))
-        else:
-            summary_status = JobStatus.DONE
-            self._repository.update_job_status(job_id, JobStatus.DONE, None)
-
+        self._repository.update_job_status(job_row["job_id"], JobStatus.CANCELLED, CANCEL_REASON)
         self._send_summary(
             job_row,
             total_pages=total_pages,
             processed_pages=processed_pages,
             skipped_pages=skipped_pages,
-            errors=page_errors,
-            status=summary_status,
+            errors=errors,
+            status=JobStatus.CANCELLED,
         )
+
+    def _clear_cancellation_flag(self, job_id: str) -> None:
+        if self._admin_state is not None:
+            self._admin_state.clear_job_cancellation(job_id)
 
     def _send_page_result(self, job_row, page_index: int, result) -> Optional[str]:
         token = job_row["webhook_token"] or None


### PR DESCRIPTION
## Summary
- raise the default worker count to 10 and extend the shared request timeout to 600 seconds, updating documentation accordingly
- expose recent job activity on the admin dashboard with cancel controls and persist cancellation requests
- teach workers to detect admin cancellations, stop processing quickly, and emit cancelled summaries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce2f22fec832d8e2b7ee569accaf6