### PR TITLE
Set default worker count to 3

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -75,7 +75,7 @@ def get_settings() -> Settings:
         data_dir=data_dir,
         tmp_dir=tmp_dir,
         worker_idle_sleep=_read_float("WORKER_IDLE_SLEEP", 1.0),
-        worker_count=_read_int("WORKER_COUNT", 10, minimum=1),
+        worker_count=_read_int("WORKER_COUNT", 3, minimum=1),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
         gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
         webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),


### PR DESCRIPTION
## Summary
- update the default worker count configuration to three to limit background threads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce89ada0c832da091ac8eb4755161