### PR TITLE
Fix worker logging extra attribute

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -52,7 +52,7 @@ class JobWorker(threading.Thread):
         self._stop_event.set()
 
     def run(self) -> None:  # pragma: no cover - threading logic
-        LOGGER.info("Worker thread started", extra={"threadName": self.name})
+        LOGGER.info("Worker thread started", extra={"workerName": self.name})
         while not self._stop_event.is_set():
             try:
                 job_id = self._queue.get(timeout=self._idle_sleep)
@@ -65,7 +65,7 @@ class JobWorker(threading.Thread):
                 self._repository.update_job_status(job_id, JobStatus.ERROR, str(exc))
             finally:
                 self._queue.task_done()
-        LOGGER.info("Worker thread stopped", extra={"threadName": self.name})
+        LOGGER.info("Worker thread stopped", extra={"workerName": self.name})
 
     def _process_job(self, job_id: str) -> None:
         try:


### PR DESCRIPTION
## Summary
- rename the worker thread logging extra attribute to avoid conflicting with built-in logging fields

## Testing
- pytest
- python - <<'PY'
from app.logging_config import configure_logging
from app.worker import LOGGER
configure_logging()
LOGGER.info("Worker thread started", extra={"workerName": "example"})
LOGGER.info("Worker thread stopped", extra={"workerName": "example"})
PY

------
https://chatgpt.com/codex/tasks/task_e_68d34ede4a14832d84ede98fe066c212