### PR TITLE
Track worker assignments in job history

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -349,17 +349,18 @@ def _build_dashboard_payload(
     job_rows = []
     for job in jobs:
         cancellation_requested = state.is_cancellation_requested(job["job_id"])
-        job_rows.append(
-            {
-                "jobId": job["job_id"],
-                "orderId": job["order_id"],
-                "status": job["status"],
-                "statusLabel": job["status"],
-                "totalPages": job["total_pages"],
-                "processedPages": job["processed_pages"],
-                "skippedPages": job["skipped_pages"],
-                "lastError": job["last_error"],
-                "createdAt": _format_datetime(job["created_at"])
+                job_rows.append(
+                    {
+                        "jobId": job["job_id"],
+                        "orderId": job["order_id"],
+                        "status": job["status"],
+                        "statusLabel": job["status"],
+                        "workerName": job["worker_name"],
+                        "totalPages": job["total_pages"],
+                        "processedPages": job["processed_pages"],
+                        "skippedPages": job["skipped_pages"],
+                        "lastError": job["last_error"],
+                        "createdAt": _format_datetime(job["created_at"])
                 if job["created_at"]
                 else "-",
                 "updatedAt": _format_datetime(job["updated_at"])
@@ -499,6 +500,7 @@ def _reload_components(app: FastAPI, settings: Settings) -> None:
             webhook_dispatcher=new_webhook,
             idle_sleep=settings.worker_idle_sleep,
             admin_state=app.state.admin_state,
+            worker_number=index + 1,
             name=f"JobWorker-{index + 1}",
         )
         for index in range(settings.worker_count)

--- a/app/main.py
+++ b/app/main.py
@@ -319,6 +319,7 @@ def _build_components(admin_state: AdminState) -> tuple[dict[str, object], int]:
                 webhook_dispatcher=webhook_dispatcher,
                 idle_sleep=settings.worker_idle_sleep,
                 admin_state=admin_state,
+                worker_number=index + 1,
                 name=f"JobWorker-{index + 1}",
             )
             for index in range(settings.worker_count)

--- a/app/models.py
+++ b/app/models.py
@@ -107,6 +107,7 @@ class JobDetail(BaseModel):
     masters: Masters
     webhookUrl: HttpUrl
     webhookToken: str
+    workerName: Optional[str] = None
     createdAt: datetime
     updatedAt: datetime
     totalPages: Optional[int]

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -301,6 +301,8 @@
                   <dd class="col-sm-9 text-break">[[ job.orderId ]]</dd>
                   <dt class="col-sm-3">ステータス</dt>
                   <dd class="col-sm-9"><span class="badge text-bg-secondary">[[ job.statusLabel ]]</span></dd>
+                  <dt class="col-sm-3">担当ワーカー</dt>
+                  <dd class="col-sm-9">[[ job.workerName || '-' ]]</dd>
                   <dt class="col-sm-3">ページ進捗</dt>
                   <dd class="col-sm-9">
                     [[ job.processedPages !== null && job.totalPages !== null


### PR DESCRIPTION
## Summary
- record the worker name on each job and expose it via repository queries and the job detail response
- number JobWorker threads, persist the worker identifier when processing starts, and include the metadata in admin payloads
- surface the responsible worker in the admin console job history view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3595fe2d8832db679e6aa7ed07806