### PR TITLE
Preserve page result ordering during parallel processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ GAS(doPost) で検証・保存・集計
 - **FileFetcher**: `http(s)://`、`file://`、`local:`、および Google Drive のファイル ID に対応。Drive 利用時はサービスアカウント認証（`DRIVE_SERVICE_ACCOUNT_JSON`）を読み込み、必要に応じてトークンをリフレッシュする。
 - **GeminiClient**: `models/{model}:generateContent` を呼び出し、ページ PDF・プロンプト・マスタ CSV を 1 リクエストにまとめる。API キー未設定時はシミュレーションレスポンスを返すので、ローカル検証が容易。
 - **WebhookDispatcher**: Apps Script など 302 を返すエンドポイントにも対応できるよう `follow_redirects=True` で POST。Bearer トークンを自動付与し、失敗時は例外で呼び出し元に通知する。
-- **JobWorker**: 指定したスレッド数だけ起動され、キューからジョブを取り出して並列に処理する。ページ結果は都度 SQLite と Webhook に記録し、途中失敗時は `_handle_initial_failure` でサマリを送信してジョブを `ERROR` として終了させる。
+- **JobWorker**: 指定したスレッド数だけ起動され、キューからジョブを取り出して並列に処理する。ページ処理は Gemini 呼び出し単位でも並列化され、複数ページ PDF も単一ページ PDF 群もページごとのスレッドで同時実行できる。ページ結果は都度 SQLite と Webhook に記録し、途中失敗時は `_handle_initial_failure` でサマリを送信してジョブを `ERROR` として終了させる。
 
 ---
 
@@ -204,6 +204,7 @@ GAS(doPost) で検証・保存・集計
 | TMP_DIR                   | `/data/tmp`        | 予約（現状未使用） |
 | WORKER_IDLE_SLEEP         | `1.0`              | ワーカーがキュー待機するときの sleep 秒数 |
 | WORKER_COUNT              | `10`               | 並列実行するジョブワーカーのスレッド数 |
+| WORKER_PAGE_CONCURRENCY   | `1`                | 1 ジョブ内で同時実行するページ処理スレッド数 |
 | GEMINI_API_KEY            | なし               | 未設定だとシミュレーション動作 |
 | GEMINI_MODEL              | `gemini-2.5-flash` | 既定モデル名 |
 | WEBHOOK_URL               | なし               | 設定時はジョブ登録時の URL をこの値で上書き |

--- a/app/admin.py
+++ b/app/admin.py
@@ -499,6 +499,7 @@ def _reload_components(app: FastAPI, settings: Settings) -> None:
             gemini_client=new_gemini,
             webhook_dispatcher=new_webhook,
             idle_sleep=settings.worker_idle_sleep,
+            page_concurrency=settings.worker_page_concurrency,
             admin_state=app.state.admin_state,
             worker_number=index + 1,
             name=f"JobWorker-{index + 1}",

--- a/app/main.py
+++ b/app/main.py
@@ -318,6 +318,7 @@ def _build_components(admin_state: AdminState) -> tuple[dict[str, object], int]:
                 gemini_client=gemini_client,
                 webhook_dispatcher=webhook_dispatcher,
                 idle_sleep=settings.worker_idle_sleep,
+                page_concurrency=settings.worker_page_concurrency,
                 admin_state=admin_state,
                 worker_number=index + 1,
                 name=f"JobWorker-{index + 1}",

--- a/app/settings.py
+++ b/app/settings.py
@@ -22,6 +22,7 @@ class Settings:
     tmp_dir: Path
     worker_idle_sleep: float
     worker_count: int
+    worker_page_concurrency: int
     gemini_api_key: Optional[str]
     gemini_model: str
     webhook_timeout: float
@@ -160,6 +161,7 @@ def get_settings() -> Settings:
         tmp_dir=tmp_dir,
         worker_idle_sleep=_read_float("WORKER_IDLE_SLEEP", 1.0),
         worker_count=_read_int("WORKER_COUNT", 3, minimum=1),
+        worker_page_concurrency=_read_int("WORKER_PAGE_CONCURRENCY", 1, minimum=1),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
         gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
         webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),


### PR DESCRIPTION
## Summary
- buffer completed page tasks so worker emits Gemini logs, database updates, and webhooks in original PDF order
- clear any pending page results when cancellation is detected to keep cancellation behaviour unchanged

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3645ffebc832d8c10ac8dc0e2f76a