### PR TITLE
Track worker names in Gemini logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ GAS(doPost) で検証・保存・集計
 - **FileFetcher**: `http(s)://`、`file://`、`local:`、および Google Drive のファイル ID に対応。Drive 利用時はサービスアカウント認証（`DRIVE_SERVICE_ACCOUNT_JSON`）を読み込み、必要に応じてトークンをリフレッシュする。
 - **GeminiClient**: `models/{model}:generateContent` を呼び出し、ページ PDF・プロンプト・マスタ CSV を 1 リクエストにまとめる。API キー未設定時はシミュレーションレスポンスを返すので、ローカル検証が容易。
 - **WebhookDispatcher**: Apps Script など 302 を返すエンドポイントにも対応できるよう `follow_redirects=True` で POST。Bearer トークンを自動付与し、失敗時は例外で呼び出し元に通知する。
-- **JobWorker**: 指定したスレッド数だけ起動され、キューからジョブを取り出して並列に処理する。ページ結果は都度 SQLite と Webhook に記録し、途中失敗時は `_handle_initial_failure` でサマリを送信してジョブを `ERROR` として終了させる。
+- **JobWorker**: 指定したスレッド数だけ起動され、キューからジョブを取り出して並列に処理する。ページ処理は Gemini 呼び出し単位でも並列化され、複数ページ PDF も単一ページ PDF 群もページごとのスレッドで同時実行できる。ページ結果は都度 SQLite と Webhook に記録し、途中失敗時は `_handle_initial_failure` でサマリを送信してジョブを `ERROR` として終了させる。
+  - 管理画面の Gemini リクエスト履歴には、各ログがどの `JobWorker-*` スレッドから送信されたものかを表示する。
 
 ---
 
@@ -204,6 +205,7 @@ GAS(doPost) で検証・保存・集計
 | TMP_DIR                   | `/data/tmp`        | 予約（現状未使用） |
 | WORKER_IDLE_SLEEP         | `1.0`              | ワーカーがキュー待機するときの sleep 秒数 |
 | WORKER_COUNT              | `10`               | 並列実行するジョブワーカーのスレッド数 |
+| WORKER_PAGE_CONCURRENCY   | `1`                | 1 ジョブ内で同時実行するページ処理スレッド数 |
 | GEMINI_API_KEY            | なし               | 未設定だとシミュレーション動作 |
 | GEMINI_MODEL              | `gemini-2.5-flash` | 既定モデル名 |
 | WEBHOOK_URL               | なし               | 設定時はジョブ登録時の URL をこの値で上書き |

--- a/app/admin.py
+++ b/app/admin.py
@@ -294,6 +294,7 @@ def _build_dashboard_payload(
                 "meta": entry["meta"],
                 "error": entry["error"],
                 "request": entry["request"],
+                "workerName": entry.get("worker_name"),
             }
         )
 
@@ -499,6 +500,7 @@ def _reload_components(app: FastAPI, settings: Settings) -> None:
             gemini_client=new_gemini,
             webhook_dispatcher=new_webhook,
             idle_sleep=settings.worker_idle_sleep,
+            page_concurrency=settings.worker_page_concurrency,
             admin_state=app.state.admin_state,
             worker_number=index + 1,
             name=f"JobWorker-{index + 1}",
@@ -686,6 +688,7 @@ def register_admin_routes(app: FastAPI) -> None:
                 response_text=None,
                 meta=None,
                 error=str(exc),
+                worker_name="admin-console",
             )
             state.add_message(
                 AdminMessage(
@@ -708,6 +711,7 @@ def register_admin_routes(app: FastAPI) -> None:
             response_text=result.text,
             meta=result.meta,
             error=None,
+            worker_name="admin-console",
         )
         state.add_message(
             AdminMessage(

--- a/app/main.py
+++ b/app/main.py
@@ -318,6 +318,7 @@ def _build_components(admin_state: AdminState) -> tuple[dict[str, object], int]:
                 gemini_client=gemini_client,
                 webhook_dispatcher=webhook_dispatcher,
                 idle_sleep=settings.worker_idle_sleep,
+                page_concurrency=settings.worker_page_concurrency,
                 admin_state=admin_state,
                 worker_number=index + 1,
                 name=f"JobWorker-{index + 1}",

--- a/app/settings.py
+++ b/app/settings.py
@@ -22,6 +22,7 @@ class Settings:
     tmp_dir: Path
     worker_idle_sleep: float
     worker_count: int
+    worker_page_concurrency: int
     gemini_api_key: Optional[str]
     gemini_model: str
     webhook_timeout: float
@@ -160,6 +161,7 @@ def get_settings() -> Settings:
         tmp_dir=tmp_dir,
         worker_idle_sleep=_read_float("WORKER_IDLE_SLEEP", 1.0),
         worker_count=_read_int("WORKER_COUNT", 3, minimum=1),
+        worker_page_concurrency=_read_int("WORKER_PAGE_CONCURRENCY", 1, minimum=1),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
         gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
         webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -511,6 +511,10 @@
                   [[ log.success ? '成功' : '失敗' ]]
                 </span>
                 <span class="badge text-bg-secondary me-3">[[ log.sourceLabel ]]</span>
+                <span
+                  class="badge text-bg-info text-white me-3"
+                  v-if="log.workerName"
+                >[[ log.workerName ]]</span>
                 <span class="me-3 fw-semibold">[[ log.model ]]</span>
                 <span class="me-3 text-muted">[[ log.mimeType ]]</span>
                 <span class="text-muted small">[[ log.timestamp ]]</span>
@@ -526,6 +530,8 @@
                   <dl class="row mb-0">
                     <dt class="col-sm-3">ソース</dt>
                     <dd class="col-sm-9">[[ log.source ]]</dd>
+                    <dt class="col-sm-3">ワーカー</dt>
+                    <dd class="col-sm-9">[[ log.workerName || '(不明)' ]]</dd>
                     <dt class="col-sm-3">プロンプト</dt>
                     <dd class="col-sm-9">[[ log.promptPreview ]]</dd>
                     <dt class="col-sm-3">リクエスト</dt>

--- a/app/worker.py
+++ b/app/worker.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 import queue
 import threading
-from typing import Dict, Optional, TYPE_CHECKING
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from .file_fetcher import FileFetcher
 from .gemini import GeminiClient
@@ -38,6 +39,7 @@ class JobWorker(threading.Thread):
         admin_state: "AdminState | None" = None,
         worker_number: int,
         name: str | None = None,
+        page_concurrency: int = 1,
     ) -> None:
         worker_name = name or f"JobWorker-{worker_number}"
         super().__init__(daemon=True, name=worker_name)
@@ -50,6 +52,9 @@ class JobWorker(threading.Thread):
         self._admin_state = admin_state
         self._stop_event = threading.Event()
         self.worker_number = worker_number
+        if page_concurrency < 1:
+            raise ValueError("page_concurrency must be >= 1")
+        self._page_concurrency = page_concurrency
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -143,109 +148,151 @@ class JobWorker(threading.Thread):
             total_pages = len(pages)
             processed_pages = 0
             page_errors: list[Dict[str, str]] = []
+            target_model = gemini_config.get("model") or self._gemini.default_model
+            cancellation_requested = False
 
-            for page in pages:
-                if self._is_cancellation_requested(job_id):
-                    LOGGER.info(
-                        "Cancellation detected during page loop",
-                        extra={"jobId": job_id, "pageIndex": page.index},
-                    )
-                    self._handle_job_cancellation(
-                        job_row,
-                        total_pages,
-                        processed_pages,
-                        page_errors,
-                    )
-                    return
+            if total_pages > 0:
+                max_workers = min(self._page_concurrency, total_pages)
+                futures = {}
+                pending_results: Dict[int, Dict[str, Any]] = {}
+                next_page_to_emit = pages[0].index
+                with ThreadPoolExecutor(
+                    max_workers=max_workers,
+                    thread_name_prefix=f"{self.name}-page",
+                ) as executor:
+                    for page in pages:
+                        if self._is_cancellation_requested(job_id):
+                            LOGGER.info(
+                                "Cancellation detected before submitting page",
+                                extra={"jobId": job_id, "pageIndex": page.index},
+                            )
+                            cancellation_requested = True
+                            break
 
-                target_model = gemini_config.get("model") or self._gemini.default_model
-                request_snapshot = {
-                    "jobId": job_row["job_id"],
-                    "orderId": job_row["order_id"],
-                    "pageIndex": page.index,
-                    "prompt": job_row["prompt"],
-                    "promptLength": len(job_row["prompt"]),
-                    "masters": masters,
-                    "mastersKeys": sorted(masters.keys()),
-                    "input": {
-                        "mode": "pdf_page",
-                        "mimeType": page.mime_type,
-                        "sizeBytes": len(page.data),
-                    },
-                    "parameters": {
-                        "model": target_model,
-                        "temperature": gemini_config.get("temperature"),
-                        "topP": gemini_config.get("topP"),
-                        "topK": gemini_config.get("topK"),
-                        "maxOutputTokens": gemini_config.get("maxOutputTokens"),
-                    },
-                }
-                try:
-                    result = self._gemini.generate(
-                        model=gemini_config.get("model"),
-                        prompt=job_row["prompt"],
-                        page_bytes=page.data,
-                        mime_type=page.mime_type,
-                        masters=masters,
-                        temperature=gemini_config.get("temperature"),
-                        top_p=gemini_config.get("topP"),
-                        top_k=gemini_config.get("topK"),
-                        max_output_tokens=gemini_config.get("maxOutputTokens"),
-                    )
-                    self._repository.record_gemini_log(
-                        source="worker",
-                        prompt=job_row["prompt"],
-                        model=target_model,
-                        mime_type=page.mime_type,
-                        request=request_snapshot,
-                        success=True,
-                        response_text=result.text,
-                        meta=result.meta,
-                        error=None,
-                    )
-                    self._repository.record_page_result(
-                        job_id,
-                        page.index,
-                        status="DONE",
-                        is_non_order_page=False,
-                        raw_text=result.text,
-                        error=None,
-                        meta=result.meta,
-                    )
-                    webhook_error = self._send_page_result(job_row, page.index, result)
-                    if webhook_error:
-                        page_errors.append({"pageIndex": page.index, "message": webhook_error})
-                    else:
-                        processed_pages += 1
-                except Exception as exc:
-                    self._repository.record_gemini_log(
-                        source="worker",
-                        prompt=job_row["prompt"],
-                        model=target_model,
-                        mime_type=page.mime_type,
-                        request=request_snapshot,
-                        success=False,
-                        response_text=None,
-                        meta=None,
-                        error=str(exc),
-                    )
-                    LOGGER.exception(
-                        "Failed to process page", extra={"jobId": job_id, "pageIndex": page.index}
-                    )
-                    self._repository.record_page_result(
-                        job_id,
-                        page.index,
-                        status="ERROR",
-                        is_non_order_page=False,
-                        raw_text=None,
-                        error=str(exc),
-                        meta=None,
-                    )
-                    page_errors.append({"pageIndex": page.index, "message": str(exc)})
+                        request_snapshot = self._build_request_snapshot(
+                            job_row,
+                            page,
+                            masters,
+                            gemini_config,
+                            target_model,
+                        )
+                        future = executor.submit(
+                            self._generate_page,
+                            page=page,
+                            prompt=job_row["prompt"],
+                            masters=masters,
+                            gemini_config=gemini_config,
+                        )
+                        futures[future] = (page, request_snapshot)
 
-            if self._is_cancellation_requested(job_id):
-                LOGGER.info("Cancellation detected before summary", extra={"jobId": job_id})
-                self._handle_job_cancellation(job_row, total_pages, processed_pages, page_errors)
+                    for future in as_completed(futures):
+                        page, request_snapshot = futures[future]
+                        if cancellation_requested or self._is_cancellation_requested(job_id):
+                            cancellation_requested = True
+                            pending_results.clear()
+                            try:
+                                future.result()
+                            except Exception:
+                                pass
+                            continue
+
+                        try:
+                            result = future.result()
+                            pending_results[page.index] = {
+                                "page": page,
+                                "request_snapshot": request_snapshot,
+                                "result": result,
+                                "exception": None,
+                            }
+                        except Exception as exc:
+                            pending_results[page.index] = {
+                                "page": page,
+                                "request_snapshot": request_snapshot,
+                                "result": None,
+                                "exception": exc,
+                            }
+
+                        while not cancellation_requested and next_page_to_emit in pending_results:
+                            outcome = pending_results.pop(next_page_to_emit)
+                            page_to_emit = outcome["page"]
+                            request_snapshot_to_emit = outcome["request_snapshot"]
+                            exc = outcome["exception"]
+
+                            if exc is None:
+                                result = outcome["result"]
+                                self._repository.record_gemini_log(
+                                    source="worker",
+                                    prompt=job_row["prompt"],
+                                    model=target_model,
+                                    mime_type=page_to_emit.mime_type,
+                                    request=request_snapshot_to_emit,
+                                    success=True,
+                                    response_text=result.text,
+                                    meta=result.meta,
+                                    error=None,
+                                    worker_name=self.name,
+                                )
+                                self._repository.record_page_result(
+                                    job_id,
+                                    page_to_emit.index,
+                                    status="DONE",
+                                    is_non_order_page=False,
+                                    raw_text=result.text,
+                                    error=None,
+                                    meta=result.meta,
+                                )
+                                webhook_error = self._send_page_result(
+                                    job_row, page_to_emit.index, result
+                                )
+                                if webhook_error:
+                                    page_errors.append(
+                                        {"pageIndex": page_to_emit.index, "message": webhook_error}
+                                    )
+                                else:
+                                    processed_pages += 1
+                            else:
+                                self._repository.record_gemini_log(
+                                    source="worker",
+                                    prompt=job_row["prompt"],
+                                    model=target_model,
+                                    mime_type=page_to_emit.mime_type,
+                                    request=request_snapshot_to_emit,
+                                    success=False,
+                                    response_text=None,
+                                    meta=None,
+                                    error=str(exc),
+                                    worker_name=self.name,
+                                )
+                                LOGGER.exception(
+                                    "Failed to process page",
+                                    extra={"jobId": job_id, "pageIndex": page_to_emit.index},
+                                )
+                                self._repository.record_page_result(
+                                    job_id,
+                                    page_to_emit.index,
+                                    status="ERROR",
+                                    is_non_order_page=False,
+                                    raw_text=None,
+                                    error=str(exc),
+                                    meta=None,
+                                )
+                                page_errors.append(
+                                    {"pageIndex": page_to_emit.index, "message": str(exc)}
+                                )
+
+                            next_page_to_emit += 1
+
+            if cancellation_requested or self._is_cancellation_requested(job_id):
+                LOGGER.info(
+                    "Cancellation detected before summary",
+                    extra={"jobId": job_id},
+                )
+                self._handle_job_cancellation(
+                    job_row,
+                    total_pages,
+                    processed_pages,
+                    page_errors,
+                )
                 return
 
             skipped_pages = max(total_pages - processed_pages, 0)
@@ -312,6 +359,56 @@ class JobWorker(threading.Thread):
     def _clear_cancellation_flag(self, job_id: str) -> None:
         if self._admin_state is not None:
             self._admin_state.clear_job_cancellation(job_id)
+
+    def _build_request_snapshot(
+        self,
+        job_row,
+        page: PagePayload,
+        masters: Dict[str, str],
+        gemini_config: Dict,
+        target_model: str,
+    ) -> Dict:
+        return {
+            "jobId": job_row["job_id"],
+            "orderId": job_row["order_id"],
+            "pageIndex": page.index,
+            "prompt": job_row["prompt"],
+            "promptLength": len(job_row["prompt"]),
+            "masters": masters,
+            "mastersKeys": sorted(masters.keys()),
+            "input": {
+                "mode": "pdf_page",
+                "mimeType": page.mime_type,
+                "sizeBytes": len(page.data),
+            },
+            "parameters": {
+                "model": target_model,
+                "temperature": gemini_config.get("temperature"),
+                "topP": gemini_config.get("topP"),
+                "topK": gemini_config.get("topK"),
+                "maxOutputTokens": gemini_config.get("maxOutputTokens"),
+            },
+        }
+
+    def _generate_page(
+        self,
+        *,
+        page: PagePayload,
+        prompt: str,
+        masters: Dict[str, str],
+        gemini_config: Dict,
+    ):
+        return self._gemini.generate(
+            model=gemini_config.get("model"),
+            prompt=prompt,
+            page_bytes=page.data,
+            mime_type=page.mime_type,
+            masters=masters,
+            temperature=gemini_config.get("temperature"),
+            top_p=gemini_config.get("topP"),
+            top_k=gemini_config.get("topK"),
+            max_output_tokens=gemini_config.get("maxOutputTokens"),
+        )
 
     def _send_page_result(self, job_row, page_index: int, result) -> Optional[str]:
         token = job_row["webhook_token"] or None

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -84,6 +84,7 @@ def test_record_and_list_gemini_logs(tmp_path: Path) -> None:
         response_text="ok",
         meta={"tokens": 10},
         error=None,
+        worker_name="admin-console",
     )
     repository.record_gemini_log(
         source="worker",
@@ -95,6 +96,7 @@ def test_record_and_list_gemini_logs(tmp_path: Path) -> None:
         response_text=None,
         meta=None,
         error="boom",
+        worker_name="JobWorker-1",
     )
 
     logs = repository.list_gemini_logs()
@@ -102,7 +104,9 @@ def test_record_and_list_gemini_logs(tmp_path: Path) -> None:
     assert logs[0]["source"] == "worker"
     assert logs[0]["success"] is False
     assert logs[0]["request"]["prompt"] == "second prompt"
+    assert logs[0]["worker_name"] == "JobWorker-1"
     assert logs[1]["prompt_preview"].startswith("first prompt")
+    assert logs[1]["worker_name"] == "admin-console"
 
     repository.close()
 


### PR DESCRIPTION
## Summary
- add worker_name column to Gemini log storage and populate it from job workers and the admin console
- surface worker names in the admin dashboard Gemini request history and document the behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3645ffebc832d8c10ac8dc0e2f76a