### PR TITLE
Add worker attribution to Gemini request logs

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -286,6 +286,7 @@ def _build_dashboard_payload(
                 "timestamp": _format_datetime(entry["timestamp"]),
                 "source": entry["source"],
                 "sourceLabel": entry["source"].upper(),
+                "workerName": entry.get("worker_name"),
                 "promptPreview": entry["prompt_preview"],
                 "model": entry["model"],
                 "mimeType": entry["mime_type"],
@@ -679,6 +680,7 @@ def register_admin_routes(app: FastAPI) -> None:
         except Exception as exc:
             repository.record_gemini_log(
                 source="admin",
+                worker_name=None,
                 prompt=prompt,
                 model=effective_model,
                 mime_type=effective_mime_type,
@@ -701,6 +703,7 @@ def register_admin_routes(app: FastAPI) -> None:
 
         repository.record_gemini_log(
             source="admin",
+            worker_name=None,
             prompt=prompt,
             model=effective_model,
             mime_type=effective_mime_type,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -511,6 +511,7 @@
                   [[ log.success ? '成功' : '失敗' ]]
                 </span>
                 <span class="badge text-bg-secondary me-3">[[ log.sourceLabel ]]</span>
+                <span class="badge text-bg-info me-3" v-if="log.workerName">[[ log.workerName ]]</span>
                 <span class="me-3 fw-semibold">[[ log.model ]]</span>
                 <span class="me-3 text-muted">[[ log.mimeType ]]</span>
                 <span class="text-muted small">[[ log.timestamp ]]</span>
@@ -526,6 +527,8 @@
                   <dl class="row mb-0">
                     <dt class="col-sm-3">ソース</dt>
                     <dd class="col-sm-9">[[ log.source ]]</dd>
+                    <dt class="col-sm-3">ワーカー</dt>
+                    <dd class="col-sm-9">[[ log.workerName || '-' ]]</dd>
                     <dt class="col-sm-3">プロンプト</dt>
                     <dd class="col-sm-9">[[ log.promptPreview ]]</dd>
                     <dt class="col-sm-3">リクエスト</dt>

--- a/app/worker.py
+++ b/app/worker.py
@@ -222,6 +222,7 @@ class JobWorker(threading.Thread):
                                 result = outcome["result"]
                                 self._repository.record_gemini_log(
                                     source="worker",
+                                    worker_name=self.name,
                                     prompt=job_row["prompt"],
                                     model=target_model,
                                     mime_type=page_to_emit.mime_type,
@@ -252,6 +253,7 @@ class JobWorker(threading.Thread):
                             else:
                                 self._repository.record_gemini_log(
                                     source="worker",
+                                    worker_name=self.name,
                                     prompt=job_row["prompt"],
                                     model=target_model,
                                     mime_type=page_to_emit.mime_type,

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -76,6 +76,7 @@ def test_record_and_list_gemini_logs(tmp_path: Path) -> None:
     repository = _create_repository(tmp_path)
     repository.record_gemini_log(
         source="admin",
+        worker_name=None,
         prompt="first prompt",
         model="model-a",
         mime_type="text/plain",
@@ -87,6 +88,7 @@ def test_record_and_list_gemini_logs(tmp_path: Path) -> None:
     )
     repository.record_gemini_log(
         source="worker",
+        worker_name="worker-1",
         prompt="second prompt",
         model="model-b",
         mime_type="application/pdf",
@@ -100,6 +102,7 @@ def test_record_and_list_gemini_logs(tmp_path: Path) -> None:
     logs = repository.list_gemini_logs()
     assert len(logs) == 2
     assert logs[0]["source"] == "worker"
+    assert logs[0]["worker_name"] == "worker-1"
     assert logs[0]["success"] is False
     assert logs[0]["request"]["prompt"] == "second prompt"
     assert logs[1]["prompt_preview"].startswith("first prompt")


### PR DESCRIPTION
## Summary
- persist the worker name for Gemini requests in the repository and expose it through the admin payload
- display the worker name in the Gemini request history accordion when available
- update worker logging and repository tests to cover the new metadata

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e374e8eca8832dbfaf803c3e0850e1