### PR TITLE
Align page page concurrency with worker count

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ GAS(doPost) で検証・保存・集計
 | SQLITE_PATH               | `/data/relay.db`   | SQLite ファイルパス |
 | TMP_DIR                   | `/data/tmp`        | 予約（現状未使用） |
 | WORKER_IDLE_SLEEP         | `1.0`              | ワーカーがキュー待機するときの sleep 秒数 |
-| WORKER_COUNT              | `10`               | 並列実行するジョブワーカーのスレッド数 |
-| WORKER_PAGE_CONCURRENCY   | `1`                | 1 ジョブ内で同時実行するページ処理スレッド数 |
+| WORKER_COUNT              | `10`               | 並列実行するジョブワーカーのスレッド数。ページ処理の同時実行数にも利用される |
 | GEMINI_API_KEY            | なし               | 未設定だとシミュレーション動作 |
 | GEMINI_MODEL              | `gemini-2.5-flash` | 既定モデル名 |
 | WEBHOOK_URL               | なし               | 設定時はジョブ登録時の URL をこの値で上書き |

--- a/app/admin.py
+++ b/app/admin.py
@@ -500,7 +500,7 @@ def _reload_components(app: FastAPI, settings: Settings) -> None:
             gemini_client=new_gemini,
             webhook_dispatcher=new_webhook,
             idle_sleep=settings.worker_idle_sleep,
-            page_concurrency=settings.worker_page_concurrency,
+            page_concurrency=settings.worker_count,
             admin_state=app.state.admin_state,
             worker_number=index + 1,
             name=f"JobWorker-{index + 1}",

--- a/app/main.py
+++ b/app/main.py
@@ -318,7 +318,7 @@ def _build_components(admin_state: AdminState) -> tuple[dict[str, object], int]:
                 gemini_client=gemini_client,
                 webhook_dispatcher=webhook_dispatcher,
                 idle_sleep=settings.worker_idle_sleep,
-                page_concurrency=settings.worker_page_concurrency,
+                page_concurrency=settings.worker_count,
                 admin_state=admin_state,
                 worker_number=index + 1,
                 name=f"JobWorker-{index + 1}",

--- a/app/settings.py
+++ b/app/settings.py
@@ -22,7 +22,6 @@ class Settings:
     tmp_dir: Path
     worker_idle_sleep: float
     worker_count: int
-    worker_page_concurrency: int
     gemini_api_key: Optional[str]
     gemini_model: str
     webhook_timeout: float
@@ -161,7 +160,6 @@ def get_settings() -> Settings:
         tmp_dir=tmp_dir,
         worker_idle_sleep=_read_float("WORKER_IDLE_SLEEP", 1.0),
         worker_count=_read_int("WORKER_COUNT", 3, minimum=1),
-        worker_page_concurrency=_read_int("WORKER_PAGE_CONCURRENCY", 1, minimum=1),
         gemini_api_key=os.getenv("GEMINI_API_KEY"),
         gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
         webhook_timeout=_read_float("WEBHOOK_TIMEOUT", 30.0),


### PR DESCRIPTION
## Summary
- derive page processing concurrency from the worker count setting
- update worker bootstrap paths to pass the shared limit value
- document the environment change in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e37dd97924832dbcadf6f07c59dc70